### PR TITLE
Feature: Send slack DM to owner of a booking on update

### DIFF
--- a/src/lib/changelogUtils.ts
+++ b/src/lib/changelogUtils.ts
@@ -16,7 +16,7 @@ import {
     updateEquipmentChangelogEntry,
     insertEquipmentChangelogEntry,
 } from './db-access/equipmentChangelogEntry';
-import { sendSlackMessageForBooking } from './slack';
+import { sendSlackDMForBooking, sendSlackMessageForBooking } from './slack';
 
 // Bookings
 //
@@ -142,6 +142,8 @@ export const logStatusChangeToBooking = (
     const message = `${user.name} ${getStatusActionString(newStatus)}.`;
 
     sendSlackMessageForBooking(message, bookingId, bookingName);
+    sendSlackDMForBooking(message, bookingId, bookingName, user);
+
     return addChangelogToBooking(message, bookingId, 0);
 };
 
@@ -180,6 +182,8 @@ export const logRentalStatusChangeToBooking = (
     const message = `${user.name} ${getRentalStatusActionString(newStatus)} ${equipmentListName}.`;
 
     sendSlackMessageForBooking(message, bookingId, bookingName);
+    sendSlackDMForBooking(message, bookingId, bookingName, user);
+
     return addChangelogToBooking(message, bookingId, 0);
 };
 

--- a/src/lib/slack.ts
+++ b/src/lib/slack.ts
@@ -1,12 +1,9 @@
 import { WebClient } from '@slack/web-api';
+import { fetchBookingWithEquipmentLists } from './db-access/booking';
+import { CurrentUserInfo } from '../models/misc/CurrentUserInfo';
 
-export const sendSlackMessage = async (message: string) => {
+export const sendSlackMessage = async (message: string, channelId: string) => {
     const client = new WebClient(process.env.SLACK_BOT_TOKEN);
-    const channelId = process.env.SLACK_CHANNEL_ID;
-
-    if (!channelId) {
-        throw new Error('Invalid slack channel id');
-    }
 
     try {
         await client.chat.postMessage({
@@ -18,9 +15,50 @@ export const sendSlackMessage = async (message: string) => {
     }
 };
 
-export const sendSlackMessageForBooking = async (message: string, bookingId: number, bookingName: string) => {
+export const sendSlackMessageForBooking = async (
+    message: string,
+    bookingId: number,
+    bookingName: string,
+    channelId: string | null = null,
+    heading = '',
+) => {
+    const prefix = heading.length > 0 ? `*${heading}*\n` : '';
     const bookingUrl = process.env.APPLICATION_BASE_URL + '/bookings/' + bookingId;
-    const formattedMessage = `<${bookingUrl}|${bookingName}> - ${message}`;
+    const formattedMessage = `${prefix}<${bookingUrl}|${bookingName}> - ${message}`;
 
-    sendSlackMessage(formattedMessage);
+    const slackChannelId = channelId ?? process.env.SLACK_CHANNEL_ID;
+
+    if (!slackChannelId) {
+        throw new Error('Invalid slack channel id');
+    }
+
+    sendSlackMessage(formattedMessage, slackChannelId);
+};
+
+// Note: The last parameter here is not the user to send to, is the user NOT to send to (since we do not want to send DMs to the user triggering the action, even if they own the booking).
+export const sendSlackDMForBooking = async (
+    message: string,
+    bookingId: number,
+    bookingName: string,
+    currentUser: CurrentUserInfo,
+) => {
+    const booking = await fetchBookingWithEquipmentLists(bookingId);
+    const ownerUserSlackId = booking.ownerUser.slackId;
+
+    if (!ownerUserSlackId) {
+        return;
+    }
+
+    // Only send any message if the current user isnt the owner
+    if (booking.ownerUser.id === currentUser.userId) {
+        return;
+    }
+
+    sendSlackMessageForBooking(
+        message,
+        bookingId,
+        bookingName,
+        ownerUserSlackId,
+        'En bokning du är ansvarig för har uppdaterats',
+    );
 };


### PR DESCRIPTION
DM is send when:
* Rental status is changed
* Booking status is changed

Vi pratade ~~i tisdags~~ _i oktober_ om att det vore nice att få lite mer påminnelse den som är ansvarig för en hyra att kolla över efter den är tillbakalämnad. Ett sätt att göra det är ju att man får en pling så man slipper komma ihåg att hålla koll på vad som händer själv.

Med denna PR skickas ett DM i slack till ägaren för en bokning när utlämningsstatus eller bokningsstatus ändras om ägaren har ett slack-id konfigurerat och det inte var ägaren själv som utförde statusändringen. Se exempel i bild nedan:

Nu är det som sagt bara utlämningsstatus och bokningsstatus som det uppdateras om, men vi kan ju lägga till fler saker (betalstatus, lönestatus, tidsrapporter, skapande av bokningar, etc) om vi tycker det är lämpligt.

![1423726317-image](https://github.com/rneventteknik/backstage2/assets/3681132/f285709d-3d30-4a5b-b5b5-e9b04ba69107)
