### PR TITLE
Feature: Add time-report page

### DIFF
--- a/src/components/admin/AdminBookingList.tsx
+++ b/src/components/admin/AdminBookingList.tsx
@@ -129,7 +129,7 @@ const AdminBookingList: React.FC<Props> = ({
                         overlay={
                             <Tooltip id="1">
                                 <strong>
-                                    Denna bokning har både fast pris och tidsrapporter. Detta stödjs inte av Stage
+                                    Denna bokning har både fast pris och tidrapporter. Detta stödjs inte av Stage
                                     fakturaexporter och bokningen behöver därför faktureras manuellt.
                                 </strong>
                             </Tooltip>

--- a/src/components/bookings/timeEstimate/TimeEstimateList.tsx
+++ b/src/components/bookings/timeEstimate/TimeEstimateList.tsx
@@ -79,7 +79,7 @@ const TimeEstimateList: React.FC<Props> = ({ bookingId, readonly, defaultLaborHo
                 </Card.Header>
                 <Card.Body>
                     <p className="text-danger">
-                        <FontAwesomeIcon icon={faExclamationCircle} /> Det gick inte att ladda tidsrapporterna.
+                        <FontAwesomeIcon icon={faExclamationCircle} /> Det gick inte att ladda tidsestimaten.
                     </p>
                     <p className="text-monospace text-muted mb-0">{error?.message}</p>
                 </Card.Body>

--- a/src/components/bookings/timeReport/TimeReportList.tsx
+++ b/src/components/bookings/timeReport/TimeReportList.tsx
@@ -40,6 +40,7 @@ import {
 import { formatDatetime, toBookingViewModel } from '../../../lib/datetimeUtils';
 import TimeReportAddButton from './TimeReportAddButton';
 import TimeReportModal from './TimeReportModal';
+import TimeReportHourDisplay from '../../utils/TimeReportHourDisplay';
 
 type Props = {
     bookingId: number;
@@ -84,7 +85,7 @@ const TimeReportList: React.FC<Props> = ({ bookingId, currentUser, readonly, def
                 </Card.Header>
                 <Card.Body>
                     <p className="text-danger">
-                        <FontAwesomeIcon icon={faExclamationCircle} /> Det gick inte att ladda tidsrapporterna.
+                        <FontAwesomeIcon icon={faExclamationCircle} /> Det gick inte att ladda tidrapporterna.
                     </p>
                     <p className="text-monospace text-muted mb-0">{error?.message}</p>
                 </Card.Body>
@@ -189,23 +190,7 @@ const TimeReportList: React.FC<Props> = ({ bookingId, currentUser, readonly, def
             size="sm"
             readonly={readonly}
         >
-            {isNaN(timeReport.billableWorkingHours) ? (
-                <span className="text-muted font-italic">Dubbelklicka för att lägga till en tid</span>
-            ) : (
-                timeReport.billableWorkingHours + ' h'
-            )}
-            {timeReport.actualWorkingHours !== timeReport.billableWorkingHours ? (
-                <OverlayTrigger
-                    overlay={
-                        <Tooltip id="1">
-                            Antalet fakturerade timmar ({timeReport.billableWorkingHours} h) skiljer sig från antalet
-                            arbetade timmar ({timeReport.actualWorkingHours} h).
-                        </Tooltip>
-                    }
-                >
-                    <FontAwesomeIcon className="ml-1" icon={faInfoCircle} />
-                </OverlayTrigger>
-            ) : null}
+            <TimeReportHourDisplay timeReport={timeReport} />
         </DoubleClickToEdit>
     );
 

--- a/src/components/layout/Topbar.tsx
+++ b/src/components/layout/Topbar.tsx
@@ -59,6 +59,11 @@ const Topbar: React.FC<Props> = ({ currentUser, globalSettings, toggleSidebar }:
                         <Link href={'/users/' + currentUser.userId} passHref>
                             <Dropdown.Item href={'/users/' + currentUser.userId}>Profil</Dropdown.Item>
                         </Link>
+                        <Link href={'/users/' + currentUser.userId + '/time-reports'} passHref>
+                            <Dropdown.Item href={'/users/' + currentUser.userId + '/time-reports'}>
+                                Tidrapporter
+                            </Dropdown.Item>
+                        </Link>
                         <Dropdown.Item onClick={() => setShowHelpModal(true)}>Hjälp</Dropdown.Item>
                         <Dropdown.Divider />
                         <Dropdown.Item onClick={logOut}>Logga ut</Dropdown.Item>

--- a/src/components/utils/TimeReportHourDisplay.tsx
+++ b/src/components/utils/TimeReportHourDisplay.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { OverlayTrigger, Tooltip } from 'react-bootstrap';
+import { TimeReport } from '../../models/interfaces';
+import { faInfoCircle } from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+
+type Props = {
+    timeReport: TimeReport;
+};
+
+const TimeReportHourDisplay: React.FC<Props> = ({ timeReport }: Props) => {
+    return (
+        <>
+            {timeReport.billableWorkingHours} h
+            {timeReport.actualWorkingHours !== timeReport.billableWorkingHours ? (
+                <OverlayTrigger
+                    overlay={
+                        <Tooltip id="1">
+                            Antalet fakturerade timmar ({timeReport.billableWorkingHours} h) skiljer sig från antalet
+                            arbetade timmar ({timeReport.actualWorkingHours} h).
+                        </Tooltip>
+                    }
+                >
+                    <FontAwesomeIcon className="ml-1" icon={faInfoCircle} />
+                </OverlayTrigger>
+            ) : null}
+        </>
+    );
+};
+
+export default TimeReportHourDisplay;

--- a/src/lib/datetimeUtils.ts
+++ b/src/lib/datetimeUtils.ts
@@ -275,7 +275,7 @@ export const getDisplayEndDatetime = (endDatetime: Date | null | undefined, hasT
     return addDays(endDatetime, -1);
 };
 
-const getFormattedInterval = (
+export const getFormattedInterval = (
     start: Date | null | undefined,
     end: Date | null | undefined,
     hasTimeValues: boolean,

--- a/src/lib/db-access/booking.ts
+++ b/src/lib/db-access/booking.ts
@@ -68,6 +68,21 @@ export const fetchBookingsForCoOwnerUser = async (userId: number): Promise<Booki
         });
 };
 
+export const fetchBookingsForTimeReportUser = async (userId: number): Promise<BookingObjectionModel[]> => {
+    ensureDatabaseIsInitialized();
+
+    return BookingObjectionModel.query()
+        .withGraphFetched('equipmentLists')
+        .withGraphFetched('timeReports.user')
+        .whereIn(
+            'id',
+            BookingObjectionModel.query()
+                .joinRelated('timeReports')
+                .where('timeReports.userId', userId)
+                .select('Booking.id'),
+        );
+};
+
 export const fetchBookingsForEquipment = async (equipmentId: number): Promise<BookingObjectionModel[]> => {
     ensureDatabaseIsInitialized();
 

--- a/src/lib/db-access/index.ts
+++ b/src/lib/db-access/index.ts
@@ -5,6 +5,7 @@ export {
     fetchBookingWithUser,
     fetchBookingsForUser,
     fetchBookingsForCoOwnerUser,
+    fetchBookingsForTimeReportUser,
     fetchBookingsForEquipment,
 } from './booking';
 export {

--- a/src/lib/pricingUtils.ts
+++ b/src/lib/pricingUtils.ts
@@ -372,22 +372,9 @@ export const calculateSalary = (
             throw new Error('Invalid data, user information is mandatory');
         }
 
-        const salaryLines = timeReportByUser.map((x) => {
-            const hourlyWageRatio = x.booking.pricePlan === PricePlan.THS ? wageRatioThs : wageRatioExternal;
-            const hourlyWage = Math.floor(x.pricePerHour * hourlyWageRatio);
-
-            return {
-                timeReportId: x.id,
-                dimension1: rs,
-                date: formatDateForForm(x?.startDatetime),
-                name: x.name
-                    ? `${x.booking.customerName} - ${x.booking.name} (${x.name})`
-                    : `${x.booking.customerName} - ${x.booking.name}`,
-                hours: x.billableWorkingHours,
-                hourlyRate: hourlyWage,
-                sum: x.billableWorkingHours * hourlyWage,
-            };
-        });
+        const salaryLines = timeReportByUser.map((x) =>
+            getSalaryForTimeReport(x, x.booking, rs, wageRatioExternal, wageRatioThs),
+        );
 
         salaryReportSections.push({
             userId: userId,
@@ -398,4 +385,27 @@ export const calculateSalary = (
     }
 
     return salaryReportSections;
+};
+
+export const getSalaryForTimeReport = (
+    x: TimeReport,
+    booking: Booking,
+    rs: string,
+    wageRatioExternal: number,
+    wageRatioThs: number,
+) => {
+    const hourlyWageRatio = booking.pricePlan === PricePlan.THS ? wageRatioThs : wageRatioExternal;
+    const hourlyWage = Math.floor(x.pricePerHour * hourlyWageRatio);
+
+    return {
+        timeReportId: x.id,
+        dimension1: rs,
+        date: formatDateForForm(x?.startDatetime),
+        name: x.name
+            ? `${booking.customerName} - ${booking.name} (${x.name})`
+            : `${booking.customerName} - ${booking.name}`,
+        hours: x.billableWorkingHours,
+        hourlyRate: hourlyWage,
+        sum: x.billableWorkingHours * hourlyWage,
+    };
 };

--- a/src/pages/api/users/[id]/timeReportBookings.ts
+++ b/src/pages/api/users/[id]/timeReportBookings.ts
@@ -1,0 +1,31 @@
+import { NextApiRequest, NextApiResponse } from 'next';
+import {
+    respondWithCustomErrorMessage,
+    respondWithEntityNotFoundResponse,
+    respondWithInvalidMethodResponse,
+} from '../../../../lib/apiResponses';
+import { withSessionContext } from '../../../../lib/sessionContext';
+import { fetchBookingsForTimeReportUser } from '../../../../lib/db-access';
+
+const handler = withSessionContext(async (req: NextApiRequest, res: NextApiResponse): Promise<void> => {
+    const userId = Number(req.query.id);
+
+    if (isNaN(userId)) {
+        respondWithEntityNotFoundResponse(res);
+        return;
+    }
+
+    switch (req.method) {
+        case 'GET':
+            await fetchBookingsForTimeReportUser(userId)
+                .then((result) => (result ? res.status(200).json(result) : respondWithEntityNotFoundResponse(res)))
+                .catch((error) => respondWithCustomErrorMessage(res, error.message));
+
+            break;
+
+        default:
+            respondWithInvalidMethodResponse(res);
+    }
+});
+
+export default handler;

--- a/src/pages/users/[id]/index.tsx
+++ b/src/pages/users/[id]/index.tsx
@@ -13,7 +13,7 @@ import Header from '../../../components/layout/Header';
 import { TwoColLoadingPage } from '../../../components/layout/LoadingPageSkeleton';
 import { bookingsFetcher, userFetcher } from '../../../lib/fetchers';
 import { ErrorPage } from '../../../components/layout/ErrorPage';
-import { faPen } from '@fortawesome/free-solid-svg-icons';
+import { faPen, faStopwatch } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import TinyBookingTable from '../../../components/TinyBookingTable';
 import { KeyValue } from '../../../models/interfaces/KeyValue';
@@ -63,6 +63,11 @@ const UserPage: React.FC<Props> = ({ user: currentUser, globalSettings }: Props)
                         </Button>
                     </Link>
                 </IfAdmin>
+                <Link href={'/users/' + user.id + '/time-reports'} passHref>
+                    <Button variant="secondary" href={'/users/' + user.id + '/time-reports'}>
+                        <FontAwesomeIcon icon={faStopwatch} className="mr-1" /> Visa tidrapporter
+                    </Button>
+                </Link>
             </Header>
 
             <Row className="mb-3">

--- a/src/pages/users/[id]/time-reports.tsx
+++ b/src/pages/users/[id]/time-reports.tsx
@@ -1,0 +1,230 @@
+import React from 'react';
+import Layout from '../../../components/layout/Layout';
+import useSwr from 'swr';
+import { useRouter } from 'next/router';
+import { Card } from 'react-bootstrap';
+import { CurrentUserInfo } from '../../../models/misc/CurrentUserInfo';
+import { useUserWithDefaultAccessAndWithSettings } from '../../../lib/useUser';
+import Header from '../../../components/layout/Header';
+import { TableLoadingPage } from '../../../components/layout/LoadingPageSkeleton';
+import { bookingsFetcher, userFetcher } from '../../../lib/fetchers';
+import { ErrorPage } from '../../../components/layout/ErrorPage';
+import { KeyValue } from '../../../models/interfaces/KeyValue';
+import { TableConfiguration, TableDisplay } from '../../../components/TableDisplay';
+import { BookingViewModel, TimeReport } from '../../../models/interfaces';
+import TableStyleLink from '../../../components/utils/TableStyleLink';
+import { getBookingDateHeadingValue, getFormattedInterval, toBookingViewModel } from '../../../lib/datetimeUtils';
+import { getGlobalSetting, groupBy, reduceSumFn } from '../../../lib/utils';
+import { getSortedList } from '../../../lib/sortIndexUtils';
+import { formatNumberAsCurrency, getSalaryForTimeReport } from '../../../lib/pricingUtils';
+import { SalaryStatus } from '../../../models/enums/SalaryStatus';
+import TimeReportHourDisplay from '../../../components/utils/TimeReportHourDisplay';
+import DoneIcon from '../../../components/utils/DoneIcon';
+
+// eslint-disable-next-line react-hooks/rules-of-hooks
+export const getServerSideProps = useUserWithDefaultAccessAndWithSettings();
+type Props = { user: CurrentUserInfo; globalSettings: KeyValue[] };
+
+interface TimeReportViewModel extends TimeReport {
+    booking: BookingViewModel;
+    displayWorkingInterval: string;
+    hourlyRate: number;
+    salarySum: number;
+}
+
+type MonthlyTimeReports = {
+    label: string;
+    id: number;
+    sortIndex: number;
+    timeReports: TimeReportViewModel[];
+};
+
+const TimeReportsPage: React.FC<Props> = ({ user: currentUser, globalSettings }: Props) => {
+    const router = useRouter();
+    const { data: user, error, isValidating } = useSwr('/api/users/' + router.query.id, userFetcher);
+    const { data: timeReportBookings } = useSwr(
+        '/api/users/' + router.query.id + '/timeReportBookings',
+        bookingsFetcher,
+    );
+
+    if (error) {
+        return (
+            <ErrorPage
+                errorMessage={error.message}
+                fixedWidth={true}
+                currentUser={currentUser}
+                globalSettings={globalSettings}
+            />
+        );
+    }
+
+    if (isValidating || !user || !timeReportBookings) {
+        return <TableLoadingPage fixedWidth={true} currentUser={currentUser} globalSettings={globalSettings} />;
+    }
+
+    // The page itself
+    //
+    const pageTitle = 'Tidrapporter: ' + user?.name;
+    const breadcrumbs = [
+        { link: '/users', displayName: 'Användare' },
+        { link: '/users/' + user.id, displayName: user?.name },
+        { link: '/users/' + user.id + '/time-reports', displayName: 'Tidrapporter' },
+    ];
+
+    // Calculate time reports data
+    //
+    const wageRatioExternal = Number(getGlobalSetting('salary.wageRatio.external', globalSettings));
+    const wageRatioThs = Number(getGlobalSetting('salary.wageRatio.ths', globalSettings));
+
+    const timeReports: TimeReportViewModel[] = timeReportBookings?.flatMap((booking) =>
+        (booking.timeReports ?? [])
+            ?.filter((timeReport) => timeReport.userId === user.id)
+            .map((x) => ({
+                ...x,
+                booking: toBookingViewModel(booking),
+                displayWorkingInterval: getFormattedInterval(x.startDatetime, x.endDatetime, true),
+                salarySum: getSalaryForTimeReport(x, booking, '', wageRatioExternal, wageRatioThs).sum,
+                hourlyRate: getSalaryForTimeReport(x, booking, '', wageRatioExternal, wageRatioThs).hourlyRate,
+            })),
+    );
+
+    // Group by month
+    const timeReportsByBookingMonth = groupBy(timeReports, (timeReport) =>
+        getBookingDateHeadingValue(timeReport.booking),
+    );
+    const monthlyTimeReports: MonthlyTimeReports[] = [];
+    for (const month in timeReportsByBookingMonth) {
+        const timeReportsForBookingMonth = timeReportsByBookingMonth[month];
+
+        monthlyTimeReports.push({
+            label: month,
+            id: monthlyTimeReports.length + 1,
+            sortIndex: -(timeReportsForBookingMonth[0].booking.usageStartDatetime?.getTime() ?? 0), // Use the time of one of the bookings for sorting
+            timeReports: timeReportsForBookingMonth,
+        });
+    }
+
+    // Table display functions
+    //
+    const TimeReportNameDisplayFn = (timeReport: TimeReportViewModel) => (
+        <>
+            <p className="mb-0">{timeReport.name}</p>
+            <p className="text-muted mb-0 d-lg-none">
+                <TimeReportHourDisplay timeReport={timeReport} />
+            </p>
+            <TableStyleLink className="text-muted" href={'/bookings/' + timeReport.booking.id}>
+                {timeReport.booking.name}
+            </TableStyleLink>
+            <p className="text-muted mb-0">{timeReport.displayWorkingInterval ?? '-'}</p>
+        </>
+    );
+
+    const TimeReportBillableWorkingHoursDisplayFn = (timeReport: TimeReportViewModel) => (
+        <TimeReportHourDisplay timeReport={timeReport} />
+    );
+
+    const TimeReportHourlyRateDisplayFn = (timeReport: TimeReportViewModel) =>
+        formatNumberAsCurrency(timeReport.hourlyRate);
+    const TimeReportSumDisplayFn = (timeReport: TimeReportViewModel) => formatNumberAsCurrency(timeReport.salarySum);
+    const TimeReportSentDisplayFn = (timeReport: TimeReportViewModel) =>
+        timeReport.booking.salaryStatus === SalaryStatus.SENT ? <DoneIcon /> : <></>;
+
+    // Use custom sort function
+    const sortByTimeFn = (a: TimeReportViewModel, b: TimeReportViewModel): number => {
+        if ((a.startDatetime ?? 0) < (b.startDatetime ?? 0)) {
+            return -1;
+        }
+
+        if ((a.startDatetime ?? 0) > (b.startDatetime ?? 0)) {
+            return 1;
+        }
+
+        return 0;
+    };
+
+    const tableSettings: TableConfiguration<TimeReportViewModel> = {
+        entityTypeDisplayName: 'bokningar',
+        defaultSortPropertyName: 'date',
+        customSortFn: sortByTimeFn,
+        defaultSortAscending: true,
+        hideTableFilter: true,
+        hideTableCountControls: true,
+        columns: [
+            {
+                key: 'name',
+                displayName: 'Tidrapport',
+                getValue: (timeReport: TimeReportViewModel) => timeReport.name,
+                getContentOverride: TimeReportNameDisplayFn,
+            },
+            {
+                key: 'hours',
+                displayName: 'Fakturerade timmar',
+                getValue: (timeReport: TimeReportViewModel) => timeReport.billableWorkingHours,
+                getContentOverride: TimeReportBillableWorkingHoursDisplayFn,
+                textAlignment: 'right',
+                columnWidth: 150,
+                cellHideSize: 'lg',
+            },
+            {
+                key: 'hourly-rate',
+                displayName: 'Timlön',
+                getValue: (timeReport: TimeReportViewModel) => timeReport.hourlyRate,
+                getContentOverride: TimeReportHourlyRateDisplayFn,
+                textAlignment: 'right',
+                columnWidth: 120,
+                cellHideSize: 'lg',
+            },
+            {
+                key: 'summa',
+                displayName: 'Summa',
+                getValue: (timeReport: TimeReportViewModel) => timeReport.salarySum,
+                getContentOverride: TimeReportSumDisplayFn,
+                textAlignment: 'right',
+                columnWidth: 120,
+            },
+            {
+                key: 'sent',
+                displayName: 'Skickad',
+                getValue: (timeReport: TimeReportViewModel) =>
+                    timeReport.booking.salaryStatus === SalaryStatus.SENT ? 'Ja' : 'Nej',
+                getContentOverride: TimeReportSentDisplayFn,
+                textAlignment: 'center',
+                columnWidth: 80,
+                cellHideSize: 'lg',
+            },
+        ],
+    };
+
+    return (
+        <Layout title={pageTitle} fixedWidth={true} currentUser={currentUser} globalSettings={globalSettings}>
+            <Header title={pageTitle} breadcrumbs={breadcrumbs} />
+
+            <Card className="mb-3">
+                <Card.Header className="p-1"></Card.Header>
+                <Card.Body>
+                    <p className="text-muted flex-grow-1 mb-0">
+                        <strong>Notera:</strong> Beroende på hur länge bokningar pågår, när bokningar klarmarkeras, och
+                        andra faktorer så kan timarvode i vissa fall betalas ut i en senare månad än angett nedan.
+                    </p>
+                </Card.Body>
+            </Card>
+
+            {getSortedList(monthlyTimeReports).map((timeReportMonth) => (
+                <Card className="mb-3 mt-3" key={timeReportMonth.id}>
+                    <Card.Header>
+                        <strong>{timeReportMonth.label}</strong>
+                    </Card.Header>
+                    <TableDisplay entities={timeReportMonth.timeReports} configuration={tableSettings} />
+                    <Card.Footer>
+                        Totalt timarvode för perioden:{' '}
+                        {formatNumberAsCurrency(
+                            timeReportMonth.timeReports.map((x) => x.salarySum).reduce(reduceSumFn),
+                        )}
+                    </Card.Footer>
+                </Card>
+            ))}
+        </Layout>
+    );
+};
+
+export default TimeReportsPage;


### PR DESCRIPTION
En sida där man kan se sina tidsrapporter och hur mycket man kommer få i lön, som diskuterat igår. Passade även på att justera några “tidsrapporter“ till “tidrapporter“ när jag ändå var igång.

---

Några designbeslut alla jag tagit som är bra att veta om:

- Bokningarna är grupperade på bokningens startdatum. Detta är konsekvent med hur vi gör överallt annars, men jag vet inte hur ekonomichef brukar hantera det vid löneutbetalning. Om en bokning startar 31a och slutar 3e, vilken månad får man lön i? Oavsett hur de fallen hanteras kan det ju även vara cornercases där evenemang pågår över flera månader (som vårt allas favoritspecialfall: international reception), och då kommer de ju hamna i fel månad oavsett - men att det sker ibland tycker jag är ok. Vi kommer ju aldrig vara 100% korrekta eftersom det är mänsklig faktor i när lönen kan betalas ut. Jag la i alla fall in en varning högst upp om att datumen inte alltid stämmer.
- Alla kan se varandras tidsrapporter (inklusive admins, vanliga användare, och readonly)
- Jag la in en länk i topmeny-dropdownen till ens egna sida så det är enklare att hitta. Jag tycker det är bra att ha allt som “rör en själv“ där.
- Jag började använda den nya “timarvode“-nomenklaturen för att annars skulle jag behöva skriva “lön“ överallt, och de vill vi ju inte. Jag har inte uppdaterat existerande admin-UI (löneunderlag).
- Jag visar inga bokningstatusar i listan…
- …men jag visar om lönen är skickad eller inte. Det värdet går alltså från att vara “admin only“-ish till att visas för alla användare.

![1157928842-image](https://github.com/rneventteknik/backstage2/assets/3681132/b00e24f5-7154-482f-bfd7-f4305d05d7e7)
![3181389866-image](https://github.com/rneventteknik/backstage2/assets/3681132/7f55baee-2f42-43e5-a653-a4a516e7b6be)
![2476662946-image](https://github.com/rneventteknik/backstage2/assets/3681132/7e45caac-6e5d-453e-8c41-0c340c8e0481)