### PR TITLE
Bugfix: Fix inconsistent non-admin access to settings

### DIFF
--- a/src/pages/api/customers/index.ts
+++ b/src/pages/api/customers/index.ts
@@ -13,7 +13,7 @@ const handler = withSessionContext(
     async (req: NextApiRequest, res: NextApiResponse, context: SessionContext): Promise<Promise<void> | void> => {
         switch (req.method) {
             case 'POST':
-                if (context.currentUser.role == Role.READONLY) {
+                if (context.currentUser.role != Role.ADMIN) {
                     respondWithAccessDeniedResponse(res);
                     return;
                 }

--- a/src/pages/api/equipmentLocations/index.ts
+++ b/src/pages/api/equipmentLocations/index.ts
@@ -17,7 +17,7 @@ const handler = withSessionContext(
     async (req: NextApiRequest, res: NextApiResponse, context: SessionContext): Promise<Promise<void> | void> => {
         switch (req.method) {
             case 'POST':
-                if (context.currentUser.role == Role.READONLY) {
+                if (context.currentUser.role != Role.ADMIN) {
                     respondWithAccessDeniedResponse(res);
                     return;
                 }

--- a/src/pages/api/equipmentPublicCategories/index.ts
+++ b/src/pages/api/equipmentPublicCategories/index.ts
@@ -17,7 +17,7 @@ const handler = withSessionContext(
     async (req: NextApiRequest, res: NextApiResponse, context: SessionContext): Promise<Promise<void> | void> => {
         switch (req.method) {
             case 'POST':
-                if (context.currentUser.role == Role.READONLY) {
+                if (context.currentUser.role != Role.ADMIN) {
                     respondWithAccessDeniedResponse(res);
                     return;
                 }

--- a/src/pages/api/equipmentTags/index.ts
+++ b/src/pages/api/equipmentTags/index.ts
@@ -17,7 +17,7 @@ const handler = withSessionContext(
     async (req: NextApiRequest, res: NextApiResponse, context: SessionContext): Promise<Promise<void> | void> => {
         switch (req.method) {
             case 'POST':
-                if (context.currentUser.role == Role.READONLY) {
+                if (context.currentUser.role != Role.ADMIN) {
                     respondWithAccessDeniedResponse(res);
                     return;
                 }

--- a/src/pages/settings.tsx
+++ b/src/pages/settings.tsx
@@ -17,9 +17,10 @@ import EquipmentPublicCategoryEditor from '../components/settings/EquipmentPubli
 import CustomerEditor from '../components/settings/CustomerEditor';
 import GeneralSettingsEditor from '../components/settings/GeneralSettingsEditor';
 import { KeyValue } from '../models/interfaces/KeyValue';
+import { Role } from '../models/enums/Role';
 
 // eslint-disable-next-line react-hooks/rules-of-hooks
-export const getServerSideProps = useUserWithDefaultAccessAndWithSettings();
+export const getServerSideProps = useUserWithDefaultAccessAndWithSettings(Role.ADMIN);
 type Props = { user: CurrentUserInfo; globalSettings: KeyValue[] };
 const pageTitle = 'Inställningar';
 const breadcrumbs = [{ link: 'settings', displayName: pageTitle }];


### PR DESCRIPTION
Now non-admins can't access the page and get only GET data from the APIs.

Previously they could view and add entities, but not edit or delete them.