### PR TITLE
Feature: Currency object in DB-mapping layer

### DIFF
--- a/src/components/LargeEquipmentTable.tsx
+++ b/src/components/LargeEquipmentTable.tsx
@@ -9,7 +9,7 @@ import { faEyeSlash, faTags } from '@fortawesome/free-solid-svg-icons';
 import TableStyleLink from './utils/TableStyleLink';
 import useSwr from 'swr';
 import { equipmentLocationsFetcher, equipmentTagsFetcher } from '../lib/fetchers';
-import { formatPrice, addVATToPriceWithTHS, formatTHSPrice, addVAT } from '../lib/pricingUtils';
+import { formatPrice, addVATToPriceWithTHS, formatTHSPrice, addVAT, convertPriceToCurrencyWithTHS } from '../lib/pricingUtils';
 import EquipmentTagDisplay from './utils/EquipmentTagDisplay';
 import { EquipmentLocation } from '../models/interfaces/EquipmentLocation';
 import { getSortedList } from '../lib/sortIndexUtils';
@@ -49,9 +49,9 @@ const EquipmentPriceDisplayFn = (equipment: Equipment) => {
             }
             return (
                 <>
-                    {formatPrice(addVATToPriceWithTHS(equipment.prices[0]))}
+                    {formatPrice(addVATToPriceWithTHS(convertPriceToCurrencyWithTHS(equipment.prices[0])))}
                     <br />
-                    {formatTHSPrice(addVATToPriceWithTHS(equipment.prices[0]))}
+                    {formatTHSPrice(addVATToPriceWithTHS(convertPriceToCurrencyWithTHS(equipment.prices[0])))}
                 </>
             );
         default:
@@ -64,9 +64,9 @@ const EquipmentPriceDisplayFn = (equipment: Equipment) => {
                                 {equipment.prices.map((p) => (
                                     <p key={p.id}>
                                         <h2 style={{ fontSize: '1em' }}>{p.name}</h2>
-                                        {formatPrice(addVATToPriceWithTHS(p))}
+                                        {formatPrice(addVATToPriceWithTHS(convertPriceToCurrencyWithTHS(p)))}
                                         <br />
-                                        {formatTHSPrice(addVATToPriceWithTHS(p))}
+                                        {formatTHSPrice(addVATToPriceWithTHS(convertPriceToCurrencyWithTHS(p)))}
                                     </p>
                                 ))}
                             </small>

--- a/src/components/LargeEquipmentTable.tsx
+++ b/src/components/LargeEquipmentTable.tsx
@@ -9,7 +9,7 @@ import { faEyeSlash, faTags } from '@fortawesome/free-solid-svg-icons';
 import TableStyleLink from './utils/TableStyleLink';
 import useSwr from 'swr';
 import { equipmentLocationsFetcher, equipmentTagsFetcher } from '../lib/fetchers';
-import { formatPrice, addVATToPriceWithTHS, formatTHSPrice, addVAT, convertPriceToCurrencyWithTHS } from '../lib/pricingUtils';
+import { formatPrice, addVATToPriceWithTHS, formatTHSPrice, addVAT } from '../lib/pricingUtils';
 import EquipmentTagDisplay from './utils/EquipmentTagDisplay';
 import { EquipmentLocation } from '../models/interfaces/EquipmentLocation';
 import { getSortedList } from '../lib/sortIndexUtils';
@@ -49,9 +49,9 @@ const EquipmentPriceDisplayFn = (equipment: Equipment) => {
             }
             return (
                 <>
-                    {formatPrice(addVATToPriceWithTHS(convertPriceToCurrencyWithTHS(equipment.prices[0])))}
+                    {formatPrice(addVATToPriceWithTHS((equipment.prices[0])))}
                     <br />
-                    {formatTHSPrice(addVATToPriceWithTHS(convertPriceToCurrencyWithTHS(equipment.prices[0])))}
+                    {formatTHSPrice(addVATToPriceWithTHS((equipment.prices[0])))}
                 </>
             );
         default:
@@ -64,9 +64,9 @@ const EquipmentPriceDisplayFn = (equipment: Equipment) => {
                                 {equipment.prices.map((p) => (
                                     <p key={p.id}>
                                         <h2 style={{ fontSize: '1em' }}>{p.name}</h2>
-                                        {formatPrice(addVATToPriceWithTHS(convertPriceToCurrencyWithTHS(p)))}
+                                        {formatPrice(addVATToPriceWithTHS((p)))}
                                         <br />
-                                        {formatTHSPrice(addVATToPriceWithTHS(convertPriceToCurrencyWithTHS(p)))}
+                                        {formatTHSPrice(addVATToPriceWithTHS((p)))}
                                     </p>
                                 ))}
                             </small>
@@ -121,10 +121,10 @@ const tableSettings: TableConfiguration<Equipment> = {
             getValue: (equipment: Equipment) =>
                 equipment.prices && equipment.prices.length === 1
                     ? addVAT(
-                          equipment.prices[0].pricePerHour +
-                              equipment.prices[0].pricePerUnit +
-                              equipment.prices[0].pricePerHourTHS +
-                              equipment.prices[0].pricePerUnitTHS,
+                          equipment.prices[0].pricePerHour.add(
+                              equipment.prices[0].pricePerUnit).add(
+                              equipment.prices[0].pricePerHourTHS).add(
+                              equipment.prices[0].pricePerUnitTHS),
                       ).divide(4).value
                     : -Infinity,
             getContentOverride: EquipmentPriceDisplayFn,

--- a/src/components/LargeEquipmentTable.tsx
+++ b/src/components/LargeEquipmentTable.tsx
@@ -49,9 +49,9 @@ const EquipmentPriceDisplayFn = (equipment: Equipment) => {
             }
             return (
                 <>
-                    {formatPrice(addVATToPriceWithTHS((equipment.prices[0])))}
+                    {formatPrice(addVATToPriceWithTHS(equipment.prices[0]))}
                     <br />
-                    {formatTHSPrice(addVATToPriceWithTHS((equipment.prices[0])))}
+                    {formatTHSPrice(addVATToPriceWithTHS(equipment.prices[0]))}
                 </>
             );
         default:
@@ -64,9 +64,9 @@ const EquipmentPriceDisplayFn = (equipment: Equipment) => {
                                 {equipment.prices.map((p) => (
                                     <p key={p.id}>
                                         <h2 style={{ fontSize: '1em' }}>{p.name}</h2>
-                                        {formatPrice(addVATToPriceWithTHS((p)))}
+                                        {formatPrice(addVATToPriceWithTHS(p))}
                                         <br />
-                                        {formatTHSPrice(addVATToPriceWithTHS((p)))}
+                                        {formatTHSPrice(addVATToPriceWithTHS(p))}
                                     </p>
                                 ))}
                             </small>
@@ -121,10 +121,10 @@ const tableSettings: TableConfiguration<Equipment> = {
             getValue: (equipment: Equipment) =>
                 equipment.prices && equipment.prices.length === 1
                     ? addVAT(
-                          equipment.prices[0].pricePerHour.add(
-                              equipment.prices[0].pricePerUnit).add(
-                              equipment.prices[0].pricePerHourTHS).add(
-                              equipment.prices[0].pricePerUnitTHS),
+                          equipment.prices[0].pricePerHour
+                              .add(equipment.prices[0].pricePerUnit)
+                              .add(equipment.prices[0].pricePerHourTHS)
+                              .add(equipment.prices[0].pricePerUnitTHS),
                       ).divide(4).value
                     : -Infinity,
             getContentOverride: EquipmentPriceDisplayFn,

--- a/src/components/admin/AdminBookingList.tsx
+++ b/src/components/admin/AdminBookingList.tsx
@@ -23,7 +23,7 @@ import { DoubleClickToEdit } from '../utils/DoubleClickToEdit';
 import FixedPriceStatusTag from '../utils/FixedPriceStatusTag';
 import TableStyleLink from '../utils/TableStyleLink';
 import { getBookingDateHeadingValue } from '../../lib/datetimeUtils';
-import { addVAT, formatNumberAsCurrency, getBookingPrice } from '../../lib/pricingUtils';
+import { addVAT, formatCurrency, getBookingPrice } from '../../lib/pricingUtils';
 
 type Props = {
     bookings: BookingViewModel[];
@@ -144,7 +144,7 @@ const AdminBookingList: React.FC<Props> = ({
                 <p className="text-muted mb-0">{booking.ownerUser?.name ?? '-'}</p>
                 <p className="text-muted mb-0 d-lg-none">{replaceEmptyStringWithNull(booking.invoiceNumber) ?? '-'}</p>
                 <p className="text-muted mb-0 d-lg-none">{booking.displayUsageStartString ?? '-'}</p>
-                <p className="text-muted mb-0">{formatNumberAsCurrency(addVAT(getBookingPrice(booking)))}</p>
+                <p className="text-muted mb-0">{formatCurrency(addVAT(getBookingPrice(booking)))}</p>
             </>
         );
     };

--- a/src/components/bookings/BookingForm.tsx
+++ b/src/components/bookings/BookingForm.tsx
@@ -27,6 +27,7 @@ import { FormNumberFieldWithoutScroll } from '../utils/FormNumberFieldWithoutScr
 import { Language } from '../../models/enums/Language';
 import BookingSearchCustomerModal from './BookingSearchCustomerModal';
 import PriceWithVATPreview from '../utils/PriceWithVATPreview';
+import currency from 'currency.js';
 
 type Props = {
     handleSubmitBooking: (booking: Partial<IBookingObjectionModel>) => void;
@@ -395,7 +396,7 @@ const BookingForm: React.FC<Props> = ({
                                         <InputGroup.Text>kr</InputGroup.Text>
                                     </InputGroup.Append>
                                 </InputGroup>
-                                <PriceWithVATPreview price={toIntOrUndefined(fixedPrice)} />
+                                <PriceWithVATPreview price={currency(fixedPrice ?? 0)} />
                                 <Form.Text className="text-muted">
                                     Om detta fält har ett värde skriver det över summan som beräknas från
                                     utrustningslistor och arbetstid. Detta fält ska normalt lämnas tomt.

--- a/src/components/bookings/equipmentLists/CopyEquipmentListEntriesModal.tsx
+++ b/src/components/bookings/equipmentLists/CopyEquipmentListEntriesModal.tsx
@@ -9,7 +9,7 @@ import { getResponseContentOrError, toIntOrUndefined } from '../../../lib/utils'
 import { toBooking } from '../../../lib/mappers/booking';
 import { IBookingObjectionModel } from '../../../models/objection-models';
 import { getSortedList, sortIndexSortFn } from '../../../lib/sortIndexUtils';
-import { convertPriceToCurrency, formatNumberAsCurrency, formatPrice } from '../../../lib/pricingUtils';
+import { formatCurrency, formatPrice } from '../../../lib/pricingUtils';
 import { Booking, Equipment, EquipmentPrice } from '../../../models/interfaces';
 import { PricePlan } from '../../../models/enums/PricePlan';
 import { TableConfiguration, TableDisplay } from '../../TableDisplay';
@@ -364,7 +364,7 @@ const CopyEquipmentListEntriesModal: React.FC<Props> = ({ show, onHide, onImport
 
         const entry = getEquipmentListEntryFromViewModel(viewModel);
 
-        return entry.discount ? <span className="text-danger">{formatNumberAsCurrency(entry.discount)}</span> : '-';
+        return entry.discount ? <span className="text-danger">{formatCurrency(entry.discount)}</span> : '-';
     };
 
     const EquipmentListEntryPriceDisplayFn = (viewModel: ViewModel) => {
@@ -376,7 +376,7 @@ const CopyEquipmentListEntriesModal: React.FC<Props> = ({ show, onHide, onImport
 
         return (
             <>
-                {formatPrice(convertPriceToCurrency(entry))}
+                {formatPrice((entry))}
                 {resetPrices &&
                 entry.equipment &&
                 entry.equipmentPrice &&
@@ -389,7 +389,7 @@ const CopyEquipmentListEntriesModal: React.FC<Props> = ({ show, onHide, onImport
                             <Tooltip id="1">
                                 Priset kommer återställas till:
                                 <br />
-                                <em>{formatPrice(convertPriceToCurrency(getEquipmentListEntryPrices(entry.equipmentPrice)))}</em>
+                                <em>{formatPrice((getEquipmentListEntryPrices(entry.equipmentPrice)))}</em>
                             </Tooltip>
                         }
                     >
@@ -409,7 +409,7 @@ const CopyEquipmentListEntriesModal: React.FC<Props> = ({ show, onHide, onImport
                                 <br />
                                 <em>
                                     {entry.equipment.prices[0].name}:{' '}
-                                    {formatPrice(convertPriceToCurrency(getEquipmentListEntryPrices(entry.equipment.prices[0])))}
+                                    {formatPrice((getEquipmentListEntryPrices(entry.equipment.prices[0])))}
                                 </em>
                             </Tooltip>
                         }
@@ -482,7 +482,7 @@ const CopyEquipmentListEntriesModal: React.FC<Props> = ({ show, onHide, onImport
                 key: 'discount',
                 displayName: 'Rabatt',
                 getValue: (viewModel: ViewModel) =>
-                    viewModelIsHeading(viewModel) ? '' : getEquipmentListEntryFromViewModel(viewModel).discount,
+                    viewModelIsHeading(viewModel) ? '' : getEquipmentListEntryFromViewModel(viewModel).discount.value,
                 getContentOverride: EquipmentListEntryDiscountDisplayFn,
                 textAlignment: 'right',
                 columnWidth: 100,

--- a/src/components/bookings/equipmentLists/CopyEquipmentListEntriesModal.tsx
+++ b/src/components/bookings/equipmentLists/CopyEquipmentListEntriesModal.tsx
@@ -9,7 +9,7 @@ import { getResponseContentOrError, toIntOrUndefined } from '../../../lib/utils'
 import { toBooking } from '../../../lib/mappers/booking';
 import { IBookingObjectionModel } from '../../../models/objection-models';
 import { getSortedList, sortIndexSortFn } from '../../../lib/sortIndexUtils';
-import { formatNumberAsCurrency, formatPrice } from '../../../lib/pricingUtils';
+import { convertPriceToCurrency, formatNumberAsCurrency, formatPrice } from '../../../lib/pricingUtils';
 import { Booking, Equipment, EquipmentPrice } from '../../../models/interfaces';
 import { PricePlan } from '../../../models/enums/PricePlan';
 import { TableConfiguration, TableDisplay } from '../../TableDisplay';
@@ -376,7 +376,7 @@ const CopyEquipmentListEntriesModal: React.FC<Props> = ({ show, onHide, onImport
 
         return (
             <>
-                {formatPrice({ pricePerHour: entry.pricePerHour, pricePerUnit: entry.pricePerUnit })}
+                {formatPrice(convertPriceToCurrency(entry))}
                 {resetPrices &&
                 entry.equipment &&
                 entry.equipmentPrice &&
@@ -389,7 +389,7 @@ const CopyEquipmentListEntriesModal: React.FC<Props> = ({ show, onHide, onImport
                             <Tooltip id="1">
                                 Priset kommer återställas till:
                                 <br />
-                                <em>{formatPrice(getEquipmentListEntryPrices(entry.equipmentPrice))}</em>
+                                <em>{formatPrice(convertPriceToCurrency(getEquipmentListEntryPrices(entry.equipmentPrice)))}</em>
                             </Tooltip>
                         }
                     >
@@ -409,7 +409,7 @@ const CopyEquipmentListEntriesModal: React.FC<Props> = ({ show, onHide, onImport
                                 <br />
                                 <em>
                                     {entry.equipment.prices[0].name}:{' '}
-                                    {formatPrice(getEquipmentListEntryPrices(entry.equipment.prices[0]))}
+                                    {formatPrice(convertPriceToCurrency(getEquipmentListEntryPrices(entry.equipment.prices[0])))}
                                 </em>
                             </Tooltip>
                         }

--- a/src/components/bookings/equipmentLists/CopyEquipmentListEntriesModal.tsx
+++ b/src/components/bookings/equipmentLists/CopyEquipmentListEntriesModal.tsx
@@ -376,7 +376,7 @@ const CopyEquipmentListEntriesModal: React.FC<Props> = ({ show, onHide, onImport
 
         return (
             <>
-                {formatPrice((entry))}
+                {formatPrice(entry)}
                 {resetPrices &&
                 entry.equipment &&
                 entry.equipmentPrice &&
@@ -389,7 +389,7 @@ const CopyEquipmentListEntriesModal: React.FC<Props> = ({ show, onHide, onImport
                             <Tooltip id="1">
                                 Priset kommer återställas till:
                                 <br />
-                                <em>{formatPrice((getEquipmentListEntryPrices(entry.equipmentPrice)))}</em>
+                                <em>{formatPrice(getEquipmentListEntryPrices(entry.equipmentPrice))}</em>
                             </Tooltip>
                         }
                     >
@@ -409,7 +409,7 @@ const CopyEquipmentListEntriesModal: React.FC<Props> = ({ show, onHide, onImport
                                 <br />
                                 <em>
                                     {entry.equipment.prices[0].name}:{' '}
-                                    {formatPrice((getEquipmentListEntryPrices(entry.equipment.prices[0])))}
+                                    {formatPrice(getEquipmentListEntryPrices(entry.equipment.prices[0]))}
                                 </em>
                             </Tooltip>
                         }

--- a/src/components/bookings/equipmentLists/EditEquipmentListEntryModal.tsx
+++ b/src/components/bookings/equipmentLists/EditEquipmentListEntryModal.tsx
@@ -10,11 +10,13 @@ import { Typeahead } from 'react-bootstrap-typeahead';
 import PriceWithVATPreview from '../../utils/PriceWithVATPreview';
 import { KeyValue } from '../../../models/interfaces/KeyValue';
 import RequiredIndicator from '../../utils/RequiredIndicator';
+import { PricedEntityWithTHSCurrency } from '../../../models/interfaces/BaseEntity';
+import { convertPriceToCurrencyWithTHS } from '../../../lib/pricingUtils';
 
 type Props = {
     show: boolean;
     onHide: () => void;
-    priceDisplayFn: (price: EquipmentPrice) => string;
+    priceDisplayFn: (price: PricedEntityWithTHSCurrency) => string;
     getEquipmentListEntryPrices: (equipmentPrice: EquipmentPrice) => {
         pricePerHour: number;
         pricePerUnit: number;
@@ -139,7 +141,7 @@ const EditEquipmentListEntryModal: React.FC<Props> = ({
                                         <option value={undefined}>Anpassat pris</option>
                                         {equipmentListEntryToEditViewModel.equipment?.prices?.map((x) => (
                                             <option key={x.id.toString()} value={x.id.toString()}>
-                                                {x.name} {priceDisplayFn(x)}
+                                                {x.name} {priceDisplayFn(convertPriceToCurrencyWithTHS(x))}
                                             </option>
                                         ))}
                                     </Form.Control>

--- a/src/components/bookings/equipmentLists/EditEquipmentListEntryModal.tsx
+++ b/src/components/bookings/equipmentLists/EditEquipmentListEntryModal.tsx
@@ -141,7 +141,7 @@ const EditEquipmentListEntryModal: React.FC<Props> = ({
                                         <option value={undefined}>Anpassat pris</option>
                                         {equipmentListEntryToEditViewModel.equipment?.prices?.map((x) => (
                                             <option key={x.id.toString()} value={x.id.toString()}>
-                                                {x.name} {priceDisplayFn((x))}
+                                                {x.name} {priceDisplayFn(x)}
                                             </option>
                                         ))}
                                     </Form.Control>
@@ -326,9 +326,15 @@ const EditEquipmentListEntryModal: React.FC<Props> = ({
                                     description: equipmentListEntryToEditViewModel.description ?? '',
                                     numberOfUnits: Math.abs(equipmentListEntryToEditViewModel.numberOfUnits ?? 1),
                                     numberOfHours: Math.abs(equipmentListEntryToEditViewModel.numberOfHours ?? 0),
-                                    pricePerUnit: currency(Math.abs(equipmentListEntryToEditViewModel.pricePerUnit?.value ?? 0)),
-                                    pricePerHour: currency(Math.abs(equipmentListEntryToEditViewModel.pricePerHour?.value ?? 0)),
-                                    discount: currency(Math.abs(equipmentListEntryToEditViewModel.discount?.value ?? 0)),
+                                    pricePerUnit: currency(
+                                        Math.abs(equipmentListEntryToEditViewModel.pricePerUnit?.value ?? 0),
+                                    ),
+                                    pricePerHour: currency(
+                                        Math.abs(equipmentListEntryToEditViewModel.pricePerHour?.value ?? 0),
+                                    ),
+                                    discount: currency(
+                                        Math.abs(equipmentListEntryToEditViewModel.discount?.value ?? 0),
+                                    ),
                                     equipmentPrice: equipmentListEntryToEditViewModel.equipmentPrice,
                                     isHidden: equipmentListEntryToEditViewModel.isHidden ?? false,
                                     account: replaceEmptyStringWithNull(equipmentListEntryToEditViewModel.account),

--- a/src/components/bookings/equipmentLists/EditEquipmentListEntryModal.tsx
+++ b/src/components/bookings/equipmentLists/EditEquipmentListEntryModal.tsx
@@ -11,15 +11,15 @@ import PriceWithVATPreview from '../../utils/PriceWithVATPreview';
 import { KeyValue } from '../../../models/interfaces/KeyValue';
 import RequiredIndicator from '../../utils/RequiredIndicator';
 import { PricedEntityWithTHSCurrency } from '../../../models/interfaces/BaseEntity';
-import { convertPriceToCurrencyWithTHS } from '../../../lib/pricingUtils';
+import currency from 'currency.js';
 
 type Props = {
     show: boolean;
     onHide: () => void;
     priceDisplayFn: (price: PricedEntityWithTHSCurrency) => string;
     getEquipmentListEntryPrices: (equipmentPrice: EquipmentPrice) => {
-        pricePerHour: number;
-        pricePerUnit: number;
+        pricePerHour: currency;
+        pricePerUnit: currency;
         equipmentPrice: EquipmentPrice;
     };
     equipmentListEntryToEditViewModel: Partial<EquipmentListEntry> | null;
@@ -141,7 +141,7 @@ const EditEquipmentListEntryModal: React.FC<Props> = ({
                                         <option value={undefined}>Anpassat pris</option>
                                         {equipmentListEntryToEditViewModel.equipment?.prices?.map((x) => (
                                             <option key={x.id.toString()} value={x.id.toString()}>
-                                                {x.name} {priceDisplayFn(convertPriceToCurrencyWithTHS(x))}
+                                                {x.name} {priceDisplayFn((x))}
                                             </option>
                                         ))}
                                     </Form.Control>
@@ -155,11 +155,11 @@ const EditEquipmentListEntryModal: React.FC<Props> = ({
                                             type={!equipmentListEntryToEditViewModel.equipmentPrice ? 'number' : 'text'}
                                             min="0"
                                             disabled={!!equipmentListEntryToEditViewModel.equipmentPrice || readonly}
-                                            value={equipmentListEntryToEditViewModel?.pricePerUnit ?? ''}
+                                            value={equipmentListEntryToEditViewModel?.pricePerUnit?.value ?? ''}
                                             onChange={(e) =>
                                                 setEquipmentListEntryToEditViewModel({
                                                     ...equipmentListEntryToEditViewModel,
-                                                    pricePerUnit: toIntOrUndefined(e.target.value, true),
+                                                    pricePerUnit: currency(e.target.value),
                                                 })
                                             }
                                         />
@@ -176,11 +176,11 @@ const EditEquipmentListEntryModal: React.FC<Props> = ({
                                             type={!equipmentListEntryToEditViewModel.equipmentPrice ? 'number' : 'text'}
                                             min="0"
                                             disabled={!!equipmentListEntryToEditViewModel.equipmentPrice || readonly}
-                                            value={equipmentListEntryToEditViewModel?.pricePerHour ?? ''}
+                                            value={equipmentListEntryToEditViewModel?.pricePerHour?.value ?? ''}
                                             onChange={(e) =>
                                                 setEquipmentListEntryToEditViewModel({
                                                     ...equipmentListEntryToEditViewModel,
-                                                    pricePerHour: toIntOrUndefined(e.target.value, true),
+                                                    pricePerHour: currency(e.target.value),
                                                 })
                                             }
                                         />
@@ -199,12 +199,12 @@ const EditEquipmentListEntryModal: React.FC<Props> = ({
                                     <FormNumberFieldWithoutScroll
                                         type="number"
                                         min="0"
-                                        value={equipmentListEntryToEditViewModel?.discount ?? ''}
+                                        value={equipmentListEntryToEditViewModel?.discount?.value ?? ''}
                                         readOnly={readonly}
                                         onChange={(e) =>
                                             setEquipmentListEntryToEditViewModel({
                                                 ...equipmentListEntryToEditViewModel,
-                                                discount: toIntOrUndefined(e.target.value, true),
+                                                discount: currency(e.target.value),
                                             })
                                         }
                                     />
@@ -326,10 +326,10 @@ const EditEquipmentListEntryModal: React.FC<Props> = ({
                                     description: equipmentListEntryToEditViewModel.description ?? '',
                                     numberOfUnits: Math.abs(equipmentListEntryToEditViewModel.numberOfUnits ?? 1),
                                     numberOfHours: Math.abs(equipmentListEntryToEditViewModel.numberOfHours ?? 0),
-                                    pricePerUnit: Math.abs(equipmentListEntryToEditViewModel.pricePerUnit ?? 0),
-                                    pricePerHour: Math.abs(equipmentListEntryToEditViewModel.pricePerHour ?? 0),
+                                    pricePerUnit: currency(Math.abs(equipmentListEntryToEditViewModel.pricePerUnit?.value ?? 0)),
+                                    pricePerHour: currency(Math.abs(equipmentListEntryToEditViewModel.pricePerHour?.value ?? 0)),
+                                    discount: currency(Math.abs(equipmentListEntryToEditViewModel.discount?.value ?? 0)),
                                     equipmentPrice: equipmentListEntryToEditViewModel.equipmentPrice,
-                                    discount: Math.abs(equipmentListEntryToEditViewModel.discount ?? 0),
                                     isHidden: equipmentListEntryToEditViewModel.isHidden ?? false,
                                     account: replaceEmptyStringWithNull(equipmentListEntryToEditViewModel.account),
                                 };

--- a/src/components/bookings/equipmentLists/EditEquipmentListEntryModal.tsx
+++ b/src/components/bookings/equipmentLists/EditEquipmentListEntryModal.tsx
@@ -324,17 +324,11 @@ const EditEquipmentListEntryModal: React.FC<Props> = ({
                                     equipmentId: equipmentListEntryToEditViewModel.equipmentId,
                                     name: equipmentListEntryToEditViewModel.name ?? '',
                                     description: equipmentListEntryToEditViewModel.description ?? '',
-                                    numberOfUnits: Math.abs(equipmentListEntryToEditViewModel.numberOfUnits ?? 1),
-                                    numberOfHours: Math.abs(equipmentListEntryToEditViewModel.numberOfHours ?? 0),
-                                    pricePerUnit: currency(
-                                        Math.abs(equipmentListEntryToEditViewModel.pricePerUnit?.value ?? 0),
-                                    ),
-                                    pricePerHour: currency(
-                                        Math.abs(equipmentListEntryToEditViewModel.pricePerHour?.value ?? 0),
-                                    ),
-                                    discount: currency(
-                                        Math.abs(equipmentListEntryToEditViewModel.discount?.value ?? 0),
-                                    ),
+                                    numberOfUnits: equipmentListEntryToEditViewModel.numberOfUnits ?? 1,
+                                    numberOfHours: equipmentListEntryToEditViewModel.numberOfHours ?? 0,
+                                    pricePerUnit: equipmentListEntryToEditViewModel.pricePerUnit ?? currency(0),
+                                    pricePerHour: equipmentListEntryToEditViewModel.pricePerHour ?? currency(0),
+                                    discount: equipmentListEntryToEditViewModel.discount ?? currency(0),
                                     equipmentPrice: equipmentListEntryToEditViewModel.equipmentPrice,
                                     isHidden: equipmentListEntryToEditViewModel.isHidden ?? false,
                                     account: replaceEmptyStringWithNull(equipmentListEntryToEditViewModel.account),

--- a/src/components/bookings/equipmentLists/EditEquipmentListEntryModal.tsx
+++ b/src/components/bookings/equipmentLists/EditEquipmentListEntryModal.tsx
@@ -10,13 +10,13 @@ import { Typeahead } from 'react-bootstrap-typeahead';
 import PriceWithVATPreview from '../../utils/PriceWithVATPreview';
 import { KeyValue } from '../../../models/interfaces/KeyValue';
 import RequiredIndicator from '../../utils/RequiredIndicator';
-import { PricedEntityWithTHSCurrency } from '../../../models/interfaces/BaseEntity';
+import { PricedEntityWithTHS } from '../../../models/interfaces/BaseEntity';
 import currency from 'currency.js';
 
 type Props = {
     show: boolean;
     onHide: () => void;
-    priceDisplayFn: (price: PricedEntityWithTHSCurrency) => string;
+    priceDisplayFn: (price: PricedEntityWithTHS) => string;
     getEquipmentListEntryPrices: (equipmentPrice: EquipmentPrice) => {
         pricePerHour: currency;
         pricePerUnit: currency;

--- a/src/components/bookings/equipmentLists/EquipmentList.tsx
+++ b/src/components/bookings/equipmentLists/EquipmentList.tsx
@@ -338,7 +338,7 @@ const EquipmentListDisplay: React.FC<Props> = ({
         const timeEstimateToSend: ITimeEstimateObjectionModel = {
             bookingId: booking.id,
             numberOfHours: timeEstimate.numberOfHours ?? 0,
-            pricePerHour: timeEstimate.pricePerHour ?? defaultLaborHourlyRate,
+            pricePerHour: timeEstimate.pricePerHour?.value ?? defaultLaborHourlyRate,
             name: timeEstimate.name ?? '',
             sortIndex: getNextSortIndex(booking.timeEstimates ?? []),
         };

--- a/src/components/bookings/equipmentLists/EquipmentListHeader.tsx
+++ b/src/components/bookings/equipmentLists/EquipmentListHeader.tsx
@@ -18,7 +18,7 @@ import {
 import { EquipmentList, EquipmentListEntry, EquipmentListHeading } from '../../../models/interfaces/EquipmentList';
 import { toIntOrUndefined, getRentalStatusName } from '../../../lib/utils';
 import { DoubleClickToEdit } from '../../utils/DoubleClickToEdit';
-import { addVAT, formatNumberAsCurrency, getEquipmentListPrice } from '../../../lib/pricingUtils';
+import { addVAT, formatCurrency, getEquipmentListPrice } from '../../../lib/pricingUtils';
 import { PricePlan } from '../../../models/enums/PricePlan';
 import {
     formatDatetime,
@@ -343,7 +343,7 @@ const EquipmentListHeader: React.FC<Props> = ({
                 </div>
             </div>
             <p className="text-muted">
-                {formatNumberAsCurrency(addVAT(getEquipmentListPrice(list)))}
+                {formatCurrency(addVAT(getEquipmentListPrice(list)))}
                 {getNumberOfDays(list) && getNumberOfEquipmentOutDays(list) ? (
                     <>
                         {' '}

--- a/src/components/bookings/equipmentLists/EquipmentListTable.tsx
+++ b/src/components/bookings/equipmentLists/EquipmentListTable.tsx
@@ -24,8 +24,6 @@ import {
     addVAT,
     addVATToPrice,
     addVATToPriceWithTHS,
-    convertPriceToCurrency,
-    convertPriceToCurrencyWithTHS,
     formatCurrency,
     formatPrice,
     formatTHSPrice,
@@ -252,7 +250,7 @@ const EquipmentListTable: React.FC<Props> = ({
 
         const entry = getEquipmentListEntryFromViewModel(viewModel);
 
-        const valueIsRelevant = entry.pricePerUnit !== 0 || !entry.pricePerHour;
+        const valueIsRelevant = entry.pricePerUnit.value !== 0 || !entry.pricePerHour;
 
         if (!valueIsRelevant && entry.numberOfUnits === 1) {
             return <span className="text-muted">{entry.numberOfUnits} st</span>;
@@ -278,7 +276,7 @@ const EquipmentListTable: React.FC<Props> = ({
         }
 
         const entry = getEquipmentListEntryFromViewModel(viewModel);
-        const valueIsRelevant = entry.pricePerHour !== 0;
+        const valueIsRelevant = entry.pricePerHour.value !== 0;
 
         if (!valueIsRelevant && entry.numberOfHours === 0) {
             return <></>;
@@ -326,7 +324,7 @@ const EquipmentListTable: React.FC<Props> = ({
                             : [customPriceDropdownValue, ...entry.equipment.prices]
                     }
                     value={entry.equipmentPrice ?? customPriceDropdownValue}
-                    optionLabelFn={(x) => `${x.name} ${priceDisplayFn(addVATToPriceWithTHS(convertPriceToCurrencyWithTHS(x)))}`}
+                    optionLabelFn={(x) => `${x.name} ${priceDisplayFn(addVATToPriceWithTHS((x)))}`}
                     optionKeyFn={(x) => x.id.toString()}
                     onChange={(newPrice) =>
                         newPrice && newPrice.id != -1
@@ -340,7 +338,7 @@ const EquipmentListTable: React.FC<Props> = ({
                     }
                     readonly={readonly}
                 >
-                    {formatPrice(addVATToPrice(convertPriceToCurrency(entry)))}
+                    {formatPrice(addVATToPrice((entry)))}
                     {entry.equipmentPrice && entry.equipment.prices.length > 1 ? (
                         <p className="text-muted mb-0">{entry.equipmentPrice.name}</p>
                     ) : null}
@@ -348,7 +346,7 @@ const EquipmentListTable: React.FC<Props> = ({
             </span>
         ) : (
             <span className={showPricesAsMuted ? 'text-muted' : ''}>
-                {formatPrice(addVATToPrice(convertPriceToCurrency(entry)))}
+                {formatPrice(addVATToPrice((entry)))}
             </span>
         );
     };
@@ -365,7 +363,7 @@ const EquipmentListTable: React.FC<Props> = ({
 
         return (
             <em className={showPricesAsMuted ? 'text-muted' : ''}>
-                {entry.discount > 0 ? (
+                {entry.discount.value > 0 ? (
                     <OverlayTrigger
                         placement="right"
                         overlay={
@@ -723,7 +721,7 @@ const EquipmentListTable: React.FC<Props> = ({
                                                 ? equipmentPackageToAdd.name
                                                 : equipmentPackageToAdd.nameEN ?? '',
                                         numberOfHours: equipmentPackageToAdd.estimatedHours,
-                                        pricePerHour: defaultLaborHourlyRate,
+                                        pricePerHour: currency(defaultLaborHourlyRate),
                                     });
                                 } else {
                                     addEquipmentPackage(

--- a/src/components/bookings/equipmentLists/EquipmentListTable.tsx
+++ b/src/components/bookings/equipmentLists/EquipmentListTable.tsx
@@ -324,7 +324,7 @@ const EquipmentListTable: React.FC<Props> = ({
                             : [customPriceDropdownValue, ...entry.equipment.prices]
                     }
                     value={entry.equipmentPrice ?? customPriceDropdownValue}
-                    optionLabelFn={(x) => `${x.name} ${priceDisplayFn(addVATToPriceWithTHS((x)))}`}
+                    optionLabelFn={(x) => `${x.name} ${priceDisplayFn(addVATToPriceWithTHS(x))}`}
                     optionKeyFn={(x) => x.id.toString()}
                     onChange={(newPrice) =>
                         newPrice && newPrice.id != -1
@@ -338,16 +338,14 @@ const EquipmentListTable: React.FC<Props> = ({
                     }
                     readonly={readonly}
                 >
-                    {formatPrice(addVATToPrice((entry)))}
+                    {formatPrice(addVATToPrice(entry))}
                     {entry.equipmentPrice && entry.equipment.prices.length > 1 ? (
                         <p className="text-muted mb-0">{entry.equipmentPrice.name}</p>
                     ) : null}
                 </DoubleClickToEditDropdown>
             </span>
         ) : (
-            <span className={showPricesAsMuted ? 'text-muted' : ''}>
-                {formatPrice(addVATToPrice((entry)))}
-            </span>
+            <span className={showPricesAsMuted ? 'text-muted' : ''}>{formatPrice(addVATToPrice(entry))}</span>
         );
     };
 

--- a/src/components/bookings/equipmentLists/EquipmentListTable.tsx
+++ b/src/components/bookings/equipmentLists/EquipmentListTable.tsx
@@ -250,7 +250,7 @@ const EquipmentListTable: React.FC<Props> = ({
 
         const entry = getEquipmentListEntryFromViewModel(viewModel);
 
-        const valueIsRelevant = entry.pricePerUnit.value !== 0 || !entry.pricePerHour;
+        const valueIsRelevant = entry.pricePerUnit.value !== 0 || entry.pricePerHour.value === 0;
 
         if (!valueIsRelevant && entry.numberOfUnits === 1) {
             return <span className="text-muted">{entry.numberOfUnits} st</span>;

--- a/src/components/bookings/equipmentLists/EquipmentListTable.tsx
+++ b/src/components/bookings/equipmentLists/EquipmentListTable.tsx
@@ -24,7 +24,9 @@ import {
     addVAT,
     addVATToPrice,
     addVATToPriceWithTHS,
-    formatNumberAsCurrency,
+    convertPriceToCurrency,
+    convertPriceToCurrencyWithTHS,
+    formatCurrency,
     formatPrice,
     formatTHSPrice,
     getCalculatedDiscount,
@@ -324,7 +326,7 @@ const EquipmentListTable: React.FC<Props> = ({
                             : [customPriceDropdownValue, ...entry.equipment.prices]
                     }
                     value={entry.equipmentPrice ?? customPriceDropdownValue}
-                    optionLabelFn={(x) => `${x.name} ${priceDisplayFn(addVATToPriceWithTHS(x))}`}
+                    optionLabelFn={(x) => `${x.name} ${priceDisplayFn(addVATToPriceWithTHS(convertPriceToCurrencyWithTHS(x)))}`}
                     optionKeyFn={(x) => x.id.toString()}
                     onChange={(newPrice) =>
                         newPrice && newPrice.id != -1
@@ -338,7 +340,7 @@ const EquipmentListTable: React.FC<Props> = ({
                     }
                     readonly={readonly}
                 >
-                    {formatPrice(addVATToPrice({ pricePerHour: entry.pricePerHour, pricePerUnit: entry.pricePerUnit }))}
+                    {formatPrice(addVATToPrice(convertPriceToCurrency(entry)))}
                     {entry.equipmentPrice && entry.equipment.prices.length > 1 ? (
                         <p className="text-muted mb-0">{entry.equipmentPrice.name}</p>
                     ) : null}
@@ -346,7 +348,7 @@ const EquipmentListTable: React.FC<Props> = ({
             </span>
         ) : (
             <span className={showPricesAsMuted ? 'text-muted' : ''}>
-                {formatPrice(addVATToPrice({ pricePerHour: entry.pricePerHour, pricePerUnit: entry.pricePerUnit }))}
+                {formatPrice(addVATToPrice(convertPriceToCurrency(entry)))}
             </span>
         );
     };
@@ -357,9 +359,9 @@ const EquipmentListTable: React.FC<Props> = ({
         }
 
         const entry = getEquipmentListEntryFromViewModel(viewModel);
-        const priceWithoutDiscount = formatNumberAsCurrency(addVAT(getPrice(entry, getNumberOfDays(list), false)));
-        const discount = formatNumberAsCurrency(addVAT(getCalculatedDiscount(entry, getNumberOfDays(list))));
-        const priceWithDiscount = formatNumberAsCurrency(addVAT(getPrice(entry, getNumberOfDays(list))));
+        const priceWithoutDiscount = formatCurrency(addVAT(getPrice(entry, getNumberOfDays(list), false)));
+        const discount = formatCurrency(addVAT(getCalculatedDiscount(entry, getNumberOfDays(list))));
+        const priceWithDiscount = formatCurrency(addVAT(getPrice(entry, getNumberOfDays(list))));
 
         return (
             <em className={showPricesAsMuted ? 'text-muted' : ''}>

--- a/src/components/bookings/timeEstimate/TimeEstimateAddButton.tsx
+++ b/src/components/bookings/timeEstimate/TimeEstimateAddButton.tsx
@@ -7,6 +7,7 @@ import { Booking } from '../../../models/interfaces';
 import TimeEstimateModal from './TimeEstimateModal';
 import { getNextSortIndex } from '../../../lib/sortIndexUtils';
 import { addTimeEstimateApiCall } from '../../../lib/equipmentListUtils';
+import currency from 'currency.js';
 
 type Props = {
     booking: Booking;
@@ -42,7 +43,7 @@ const TimeEstimateAddButton: React.FC<Props & React.ComponentProps<typeof Button
                 {...rest}
                 onClick={() => {
                     setTimeEstimateViewModel({
-                        pricePerHour: defaultLaborHourlyRate,
+                        pricePerHour: currency(defaultLaborHourlyRate),
                     });
                 }}
             >
@@ -61,7 +62,7 @@ const TimeEstimateAddButton: React.FC<Props & React.ComponentProps<typeof Button
                         id: timeEstimateViewModel?.id,
                         bookingId: booking.id,
                         numberOfHours: timeEstimateViewModel?.numberOfHours ?? 0,
-                        pricePerHour: timeEstimateViewModel?.pricePerHour ?? 0,
+                        pricePerHour: timeEstimateViewModel?.pricePerHour?.value ?? 0,
                         name: timeEstimateViewModel?.name ?? '',
                         sortIndex: getNextSortIndex(booking.timeEstimates ?? []),
                     };

--- a/src/components/bookings/timeEstimate/TimeEstimateList.tsx
+++ b/src/components/bookings/timeEstimate/TimeEstimateList.tsx
@@ -21,7 +21,7 @@ import {
 } from '@fortawesome/free-solid-svg-icons';
 import {
     addVAT,
-    formatNumberAsCurrency,
+    formatCurrency,
     getTimeEstimatePrice,
     getTotalTimeEstimatesPrice,
 } from '../../../lib/pricingUtils';
@@ -178,7 +178,7 @@ const TimeEstimateList: React.FC<Props> = ({ bookingId, readonly, defaultLaborHo
     );
 
     const TimeEstimateTotalPriceDisplayFn = (entry: TimeEstimate) => {
-        return <em>{formatNumberAsCurrency(addVAT(getTimeEstimatePrice(entry)))}</em>;
+        return <em>{formatCurrency(addVAT(getTimeEstimatePrice(entry)))}</em>;
     };
 
     const TimeEstimateEntryActionsDisplayFn = (entry: TimeEstimate) => {
@@ -277,7 +277,7 @@ const TimeEstimateList: React.FC<Props> = ({ bookingId, readonly, defaultLaborHo
                     </div>
                 </div>
                 <p className="text-muted">
-                    {formatNumberAsCurrency(addVAT(getTotalTimeEstimatesPrice(timeEstimates)))} /{' '}
+                    {formatCurrency(addVAT(getTotalTimeEstimatesPrice(timeEstimates)))} /{' '}
                     {timeEstimates.reduce((sum: number, entry: TimeEstimate) => sum + entry.numberOfHours, 0)} h
                 </p>
             </Card.Header>

--- a/src/components/bookings/timeEstimate/TimeEstimateList.tsx
+++ b/src/components/bookings/timeEstimate/TimeEstimateList.tsx
@@ -37,6 +37,7 @@ import {
 } from '../../../lib/sortIndexUtils';
 import TimeEstimateAddButton from './TimeEstimateAddButton';
 import TimeEstimateModal from './TimeEstimateModal';
+import currency from 'currency.js';
 
 type Props = {
     bookingId: number;
@@ -316,7 +317,7 @@ const TimeEstimateList: React.FC<Props> = ({ bookingId, readonly, defaultLaborHo
                             id: timeEstimateToEditViewModel.id,
                             bookingId: booking.id,
                             numberOfHours: timeEstimateToEditViewModel?.numberOfHours ?? 0,
-                            pricePerHour: timeEstimateToEditViewModel?.pricePerHour ?? 0,
+                            pricePerHour: timeEstimateToEditViewModel?.pricePerHour ?? currency(0),
                             name: timeEstimateToEditViewModel?.name ?? '',
                             sortIndex: getNextSortIndex(booking.timeEstimates ?? []),
                         };

--- a/src/components/bookings/timeEstimate/TimeEstimateList.tsx
+++ b/src/components/bookings/timeEstimate/TimeEstimateList.tsx
@@ -19,12 +19,7 @@ import {
     faPlus,
     faGears,
 } from '@fortawesome/free-solid-svg-icons';
-import {
-    addVAT,
-    formatCurrency,
-    getTimeEstimatePrice,
-    getTotalTimeEstimatesPrice,
-} from '../../../lib/pricingUtils';
+import { addVAT, formatCurrency, getTimeEstimatePrice, getTotalTimeEstimatesPrice } from '../../../lib/pricingUtils';
 import Skeleton from 'react-loading-skeleton';
 import {
     getNextSortIndex,

--- a/src/components/bookings/timeEstimate/TimeEstimateModal.tsx
+++ b/src/components/bookings/timeEstimate/TimeEstimateModal.tsx
@@ -9,6 +9,7 @@ import { Language } from '../../../models/enums/Language';
 import { useLocalStorageState } from '../../../lib/useLocalStorageState';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faAngleDown, faAngleUp } from '@fortawesome/free-solid-svg-icons';
+import currency from 'currency.js';
 
 type Props = {
     timeEstimate?: Partial<TimeEstimate>;
@@ -77,7 +78,7 @@ const TimeEstimateModal: React.FC<Props> = ({
         setTimeEstimate({
             name: name,
             numberOfHours: numberOfTechnicians * (startHour < endHour ? endHour - startHour : endHour - startHour + 24),
-            pricePerHour: defaultLaborHourlyRate,
+            pricePerHour: currency(defaultLaborHourlyRate),
         });
     };
 
@@ -219,18 +220,18 @@ const TimeEstimateModal: React.FC<Props> = ({
                                         type="text"
                                         required
                                         readOnly={readonly}
-                                        value={timeEstimate?.pricePerHour}
+                                        value={timeEstimate?.pricePerHour?.value}
                                         onChange={(e) =>
                                             setTimeEstimate({
                                                 ...timeEstimate,
-                                                pricePerHour: toIntOrUndefined(e.target.value),
+                                                pricePerHour: currency(e.target.value),
                                             })
                                         }
                                     />
                                     <InputGroup.Text>kr/h</InputGroup.Text>
                                 </InputGroup>
                                 <PriceWithVATPreview price={timeEstimate?.pricePerHour} />
-                                {timeEstimate?.pricePerHour !== defaultLaborHourlyRate ? (
+                                {timeEstimate?.pricePerHour?.value !== defaultLaborHourlyRate ? (
                                     <Form.Text className="text-muted">
                                         Standardpris för detta evenemang är:{' '}
                                         {formatNumberAsCurrency(defaultLaborHourlyRate)}/h

--- a/src/components/bookings/timeReport/TimeReportAddButton.tsx
+++ b/src/components/bookings/timeReport/TimeReportAddButton.tsx
@@ -8,6 +8,7 @@ import { BookingViewModel } from '../../../models/interfaces';
 import { CurrentUserInfo } from '../../../models/misc/CurrentUserInfo';
 import { getResponseContentOrError } from '../../../lib/utils';
 import TimeReportModal from './TimeReportModal';
+import currency from 'currency.js';
 
 type Props = {
     booking: BookingViewModel;
@@ -64,7 +65,7 @@ const TimeReportAddButton: React.FC<Props & React.ComponentProps<typeof Button>>
                         startDatetime: booking.usageStartDatetime ?? currentDateRounded,
                         endDatetime: booking.usageEndDatetime ?? currentDateRounded,
                         userId: currentUser.userId,
-                        pricePerHour: defaultLaborHourlyRate,
+                        pricePerHour: currency(defaultLaborHourlyRate),
                     });
                 }}
                 {...rest}

--- a/src/components/bookings/timeReport/TimeReportList.tsx
+++ b/src/components/bookings/timeReport/TimeReportList.tsx
@@ -21,12 +21,7 @@ import { CurrentUserInfo } from '../../../models/misc/CurrentUserInfo';
 import Skeleton from 'react-loading-skeleton';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { toTimeReport } from '../../../lib/mappers/timeReport';
-import {
-    addVAT,
-    formatCurrency,
-    getTimeReportPrice,
-    getTotalTimeReportsPrice,
-} from '../../../lib/pricingUtils';
+import { addVAT, formatCurrency, getTimeReportPrice, getTotalTimeReportsPrice } from '../../../lib/pricingUtils';
 import { useNotifications } from '../../../lib/useNotifications';
 import { DoubleClickToEdit } from '../../utils/DoubleClickToEdit';
 import {
@@ -214,9 +209,7 @@ const TimeReportList: React.FC<Props> = ({ bookingId, currentUser, readonly, def
                     </OverlayTrigger>
                 ) : null}
             </div>
-            <div className="mb-0 text-muted d-md-none">
-                {formatCurrency(addVAT(getTimeReportPrice(timeReport)))}
-            </div>
+            <div className="mb-0 text-muted d-md-none">{formatCurrency(addVAT(getTimeReportPrice(timeReport)))}</div>
         </>
     );
 

--- a/src/components/bookings/timeReport/TimeReportList.tsx
+++ b/src/components/bookings/timeReport/TimeReportList.tsx
@@ -23,7 +23,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { toTimeReport } from '../../../lib/mappers/timeReport';
 import {
     addVAT,
-    formatNumberAsCurrency,
+    formatCurrency,
     getTimeReportPrice,
     getTotalTimeReportsPrice,
 } from '../../../lib/pricingUtils';
@@ -215,7 +215,7 @@ const TimeReportList: React.FC<Props> = ({ bookingId, currentUser, readonly, def
                 ) : null}
             </div>
             <div className="mb-0 text-muted d-md-none">
-                {formatNumberAsCurrency(addVAT(getTimeReportPrice(timeReport)))}
+                {formatCurrency(addVAT(getTimeReportPrice(timeReport)))}
             </div>
         </>
     );
@@ -253,12 +253,12 @@ const TimeReportList: React.FC<Props> = ({ bookingId, currentUser, readonly, def
         const getPricePerHourIfNotDefault = (timeReport: TimeReport) => {
             return timeReport.pricePerHour === defaultLaborHourlyRate
                 ? ''
-                : formatNumberAsCurrency(addVAT(timeReport.pricePerHour)) + '/h';
+                : formatCurrency(addVAT(timeReport.pricePerHour)) + '/h';
         };
 
         return (
             <>
-                {formatNumberAsCurrency(addVAT(getTimeReportPrice(entry)))}
+                {formatCurrency(addVAT(getTimeReportPrice(entry)))}
                 <div className="text-muted font-italic mb-0">{getPricePerHourIfNotDefault(entry)}</div>
             </>
         );
@@ -301,7 +301,7 @@ const TimeReportList: React.FC<Props> = ({ bookingId, currentUser, readonly, def
             {
                 key: 'sum',
                 displayName: 'Summa',
-                getValue: (timeReport: TimeReport) => formatNumberAsCurrency(addVAT(getTimeReportPrice(timeReport))),
+                getValue: (timeReport: TimeReport) => formatCurrency(addVAT(getTimeReportPrice(timeReport))),
                 getContentOverride: TimeReportSumDisplayFn,
                 textAlignment: 'right',
                 columnWidth: 20,
@@ -342,7 +342,7 @@ const TimeReportList: React.FC<Props> = ({ bookingId, currentUser, readonly, def
                     </div>
                 </div>
                 <p className="text-muted">
-                    {formatNumberAsCurrency(addVAT(getTotalTimeReportsPrice(timeReports)))} /{' '}
+                    {formatCurrency(addVAT(getTotalTimeReportsPrice(timeReports)))} /{' '}
                     {sumBillableWorkingHours === sumActualWorkingHours ? (
                         <>{sumBillableWorkingHours} h</>
                     ) : (

--- a/src/components/bookings/timeReport/TimeReportList.tsx
+++ b/src/components/bookings/timeReport/TimeReportList.tsx
@@ -251,7 +251,7 @@ const TimeReportList: React.FC<Props> = ({ bookingId, currentUser, readonly, def
 
     const TimeReportSumDisplayFn = (entry: TimeReport) => {
         const getPricePerHourIfNotDefault = (timeReport: TimeReport) => {
-            return timeReport.pricePerHour === defaultLaborHourlyRate
+            return timeReport.pricePerHour.value === defaultLaborHourlyRate
                 ? ''
                 : formatCurrency(addVAT(timeReport.pricePerHour)) + '/h';
         };

--- a/src/components/bookings/timeReport/TimeReportList.tsx
+++ b/src/components/bookings/timeReport/TimeReportList.tsx
@@ -297,7 +297,7 @@ const TimeReportList: React.FC<Props> = ({ bookingId, currentUser, readonly, def
                 getValue: (timeReport: TimeReport) => formatCurrency(addVAT(getTimeReportPrice(timeReport))),
                 getContentOverride: TimeReportSumDisplayFn,
                 textAlignment: 'right',
-                columnWidth: 20,
+                columnWidth: 90,
                 cellHideSize: 'md',
             },
             {

--- a/src/components/bookings/timeReport/TimeReportModal.tsx
+++ b/src/components/bookings/timeReport/TimeReportModal.tsx
@@ -10,6 +10,7 @@ import { formatDatetimeForForm } from '../../../lib/datetimeUtils';
 import { getNextSortIndex } from '../../../lib/sortIndexUtils';
 import { ITimeReportObjectionModel } from '../../../models/objection-models';
 import { formatNumberAsCurrency } from '../../../lib/pricingUtils';
+import currency from 'currency.js';
 
 type Props = {
     booking: BookingViewModel;
@@ -62,7 +63,7 @@ const TimeReportModal: React.FC<Props> = ({
             userId: userId,
             startDatetime: timeReport?.startDatetime?.toISOString() ?? '',
             endDatetime: timeReport?.endDatetime?.toISOString() ?? '',
-            pricePerHour: timeReport?.pricePerHour ?? 0,
+            pricePerHour: timeReport?.pricePerHour?.value ?? 0,
             name: timeReport?.name ?? '',
             sortIndex: getNextSortIndex(booking.timeEstimates ?? []),
         };
@@ -155,18 +156,18 @@ const TimeReportModal: React.FC<Props> = ({
                                         type="text"
                                         required
                                         readOnly={readonly}
-                                        defaultValue={timeReport?.pricePerHour}
+                                        defaultValue={timeReport?.pricePerHour?.value}
                                         onChange={(e) =>
                                             setTimeReport({
                                                 ...timeReport,
-                                                pricePerHour: toIntOrUndefined(e.target.value),
+                                                pricePerHour: currency(e.target.value),
                                             })
                                         }
                                     />
                                     <InputGroup.Text>kr/h</InputGroup.Text>
                                 </InputGroup>
                                 <PriceWithVATPreview price={timeReport?.pricePerHour} />
-                                {timeReport?.pricePerHour !== defaultLaborHourlyRate ? (
+                                {timeReport?.pricePerHour?.value !== defaultLaborHourlyRate ? (
                                     <Form.Text className="text-muted">
                                         Standardpris för detta evenemang är:{' '}
                                         {formatNumberAsCurrency(defaultLaborHourlyRate)}/h

--- a/src/components/equipment/PricesEditor.tsx
+++ b/src/components/equipment/PricesEditor.tsx
@@ -2,7 +2,7 @@ import { faPlus, faTrashCan } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import React from 'react';
 import { Badge, Button, Dropdown, DropdownButton, Form, InputGroup } from 'react-bootstrap';
-import { addVATToPriceWithTHS, formatPrice, formatTHSPrice } from '../../lib/pricingUtils';
+import { addVATToPriceWithTHS, convertPriceToCurrencyWithTHS, formatPrice, formatTHSPrice } from '../../lib/pricingUtils';
 import { idSortFn } from '../../lib/sortIndexUtils';
 import { getPricePlanName, toIntOrUndefined, updateItemsInArrayById } from '../../lib/utils';
 import { PricePlan } from '../../models/enums/PricePlan';
@@ -87,7 +87,7 @@ const PricesEditor: React.FC<Props> = ({ prices, onChange }: Props) => {
                 <InputGroup.Text>kr/h</InputGroup.Text>
             </InputGroup>
             <p className="text-muted text-left mt-1 mb-0 small">
-                Pris ink. moms: {formatPrice(addVATToPriceWithTHS(price))}
+                Pris ink. moms: {formatPrice(addVATToPriceWithTHS(convertPriceToCurrencyWithTHS(price)))}
             </p>
         </>
     );
@@ -113,7 +113,7 @@ const PricesEditor: React.FC<Props> = ({ prices, onChange }: Props) => {
                 <InputGroup.Text>kr/h</InputGroup.Text>
             </InputGroup>
             <p className="text-muted text-left mt-1 mb-0 small">
-                Pris ink. moms: {formatTHSPrice(addVATToPriceWithTHS(price))}
+                Pris ink. moms: {formatTHSPrice(addVATToPriceWithTHS(convertPriceToCurrencyWithTHS(price)))}
             </p>
         </>
     );

--- a/src/components/equipment/PricesEditor.tsx
+++ b/src/components/equipment/PricesEditor.tsx
@@ -2,14 +2,15 @@ import { faPlus, faTrashCan } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import React from 'react';
 import { Badge, Button, Dropdown, DropdownButton, Form, InputGroup } from 'react-bootstrap';
-import { addVATToPriceWithTHS, convertPriceToCurrencyWithTHS, formatPrice, formatTHSPrice } from '../../lib/pricingUtils';
+import { addVATToPriceWithTHS, formatPrice, formatTHSPrice } from '../../lib/pricingUtils';
 import { idSortFn } from '../../lib/sortIndexUtils';
-import { getPricePlanName, toIntOrUndefined, updateItemsInArrayById } from '../../lib/utils';
+import { getPricePlanName, updateItemsInArrayById } from '../../lib/utils';
 import { PricePlan } from '../../models/enums/PricePlan';
 import { EquipmentPrice } from '../../models/interfaces';
 import { HasId } from '../../models/interfaces/BaseEntity';
 import { TableConfiguration, TableDisplay } from '../TableDisplay';
 import { FormNumberFieldWithoutScroll } from '../utils/FormNumberFieldWithoutScroll';
+import currency from 'currency.js';
 
 type Props = {
     prices: EquipmentPrice[];
@@ -25,10 +26,10 @@ const PricesEditor: React.FC<Props> = ({ prices, onChange }: Props) => {
         return {
             id: nextId,
             name: prices.length > 0 ? 'Pris ' + (prices.length + 1) : 'Standardpris',
-            pricePerUnit: 0,
-            pricePerHour: 0,
-            pricePerUnitTHS: 0,
-            pricePerHourTHS: 0,
+            pricePerUnit: currency(0),
+            pricePerHour: currency(0),
+            pricePerUnitTHS: currency(0),
+            pricePerHourTHS: currency(0),
         };
     };
 
@@ -73,7 +74,7 @@ const PricesEditor: React.FC<Props> = ({ prices, onChange }: Props) => {
                     type="number"
                     min="0"
                     defaultValue={price?.pricePerUnit ? price?.pricePerUnit?.toString() : ''}
-                    onChange={(e) => updatePrice({ ...price, pricePerUnit: toIntOrUndefined(e.target.value) ?? 0 })}
+                    onChange={(e) => updatePrice({ ...price, pricePerUnit: currency(e.target.value) })}
                 />
                 <InputGroup.Text>kr/st</InputGroup.Text>
             </InputGroup>
@@ -82,12 +83,12 @@ const PricesEditor: React.FC<Props> = ({ prices, onChange }: Props) => {
                     type="number"
                     min="0"
                     defaultValue={price?.pricePerHour ? price?.pricePerHour?.toString() : ''}
-                    onChange={(e) => updatePrice({ ...price, pricePerHour: toIntOrUndefined(e.target.value) ?? 0 })}
+                    onChange={(e) => updatePrice({ ...price, pricePerHour: currency(e.target.value) })}
                 />
                 <InputGroup.Text>kr/h</InputGroup.Text>
             </InputGroup>
             <p className="text-muted text-left mt-1 mb-0 small">
-                Pris ink. moms: {formatPrice(addVATToPriceWithTHS(convertPriceToCurrencyWithTHS(price)))}
+                Pris ink. moms: {formatPrice(addVATToPriceWithTHS((price)))}
             </p>
         </>
     );
@@ -99,7 +100,7 @@ const PricesEditor: React.FC<Props> = ({ prices, onChange }: Props) => {
                     type="number"
                     min="0"
                     defaultValue={price?.pricePerUnitTHS ? price?.pricePerUnitTHS?.toString() : ''}
-                    onChange={(e) => updatePrice({ ...price, pricePerUnitTHS: toIntOrUndefined(e.target.value) ?? 0 })}
+                    onChange={(e) => updatePrice({ ...price, pricePerUnitTHS: currency(e.target.value) })}
                 />
                 <InputGroup.Text>kr/st</InputGroup.Text>
             </InputGroup>
@@ -108,12 +109,12 @@ const PricesEditor: React.FC<Props> = ({ prices, onChange }: Props) => {
                     type="number"
                     min="0"
                     defaultValue={price?.pricePerHourTHS ? price?.pricePerHourTHS?.toString() : ''}
-                    onChange={(e) => updatePrice({ ...price, pricePerHourTHS: toIntOrUndefined(e.target.value) ?? 0 })}
+                    onChange={(e) => updatePrice({ ...price, pricePerHourTHS: currency(e.target.value)})}
                 />
                 <InputGroup.Text>kr/h</InputGroup.Text>
             </InputGroup>
             <p className="text-muted text-left mt-1 mb-0 small">
-                Pris ink. moms: {formatTHSPrice(addVATToPriceWithTHS(convertPriceToCurrencyWithTHS(price)))}
+                Pris ink. moms: {formatTHSPrice(addVATToPriceWithTHS((price)))}
             </p>
         </>
     );

--- a/src/components/equipment/PricesEditor.tsx
+++ b/src/components/equipment/PricesEditor.tsx
@@ -88,7 +88,7 @@ const PricesEditor: React.FC<Props> = ({ prices, onChange }: Props) => {
                 <InputGroup.Text>kr/h</InputGroup.Text>
             </InputGroup>
             <p className="text-muted text-left mt-1 mb-0 small">
-                Pris ink. moms: {formatPrice(addVATToPriceWithTHS((price)))}
+                Pris ink. moms: {formatPrice(addVATToPriceWithTHS(price))}
             </p>
         </>
     );
@@ -109,12 +109,12 @@ const PricesEditor: React.FC<Props> = ({ prices, onChange }: Props) => {
                     type="number"
                     min="0"
                     defaultValue={price?.pricePerHourTHS ? price?.pricePerHourTHS?.toString() : ''}
-                    onChange={(e) => updatePrice({ ...price, pricePerHourTHS: currency(e.target.value)})}
+                    onChange={(e) => updatePrice({ ...price, pricePerHourTHS: currency(e.target.value) })}
                 />
                 <InputGroup.Text>kr/h</InputGroup.Text>
             </InputGroup>
             <p className="text-muted text-left mt-1 mb-0 small">
-                Pris ink. moms: {formatTHSPrice(addVATToPriceWithTHS((price)))}
+                Pris ink. moms: {formatTHSPrice(addVATToPriceWithTHS(price))}
             </p>
         </>
     );

--- a/src/components/utils/PriceWithVATPreview.tsx
+++ b/src/components/utils/PriceWithVATPreview.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Form } from 'react-bootstrap';
-import { formatNumberAsCurrency, addVAT } from '../../lib/pricingUtils';
+import { addVAT, formatCurrency } from '../../lib/pricingUtils';
 
 type Props = {
     price: number | null | undefined;
@@ -11,7 +11,7 @@ const PriceWithVATPreview: React.FC<Props> = ({ price, text = 'Pris inklusive mo
     return (
         <Form.Text className="text-muted">
             {text}
-            {price != null && price != undefined ? formatNumberAsCurrency(addVAT(price)) : '-'}.
+            {price != null && price != undefined ? formatCurrency(addVAT(price)) : '-'}.
         </Form.Text>
     );
 };

--- a/src/components/utils/PriceWithVATPreview.tsx
+++ b/src/components/utils/PriceWithVATPreview.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
 import { Form } from 'react-bootstrap';
 import { addVAT, formatCurrency } from '../../lib/pricingUtils';
+import currency from 'currency.js';
 
 type Props = {
-    price: number | null | undefined;
+    price: currency | null | undefined;
     text?: string;
 };
 

--- a/src/document-templates/components/invoiceDocument.tsx
+++ b/src/document-templates/components/invoiceDocument.tsx
@@ -194,13 +194,17 @@ export const InvoiceDocument: React.FC<InvoiceDocumentProps> = ({
                                 <Text style={styles.italic}>{t('common.equipment-list.table-header.count')}</Text>
                             </TableCellFixedWidth>
                             <TableCellFixedWidth width={90} textAlign="right">
-                                <Text style={styles.italic}>{t('common.equipment-list.table-header.price-ex-vat')}</Text>
+                                <Text style={styles.italic}>
+                                    {t('common.equipment-list.table-header.price-ex-vat')}
+                                </Text>
                             </TableCellFixedWidth>
                             <TableCellFixedWidth width={90} textAlign="right">
                                 <Text style={styles.italic}>{t('invoice.account')}</Text>
                             </TableCellFixedWidth>
                             <TableCellFixedWidth width={90} textAlign="right">
-                                <Text style={styles.italic}>{t('common.equipment-list.table-header.total-price-ex-vat')}</Text>
+                                <Text style={styles.italic}>
+                                    {t('common.equipment-list.table-header.total-price-ex-vat')}
+                                </Text>
                             </TableCellFixedWidth>
                         </TableRowWithNoBorder>
                         {invoiceData.invoiceRows.map((invoiceRow, index) => (

--- a/src/document-templates/components/invoiceDocument.tsx
+++ b/src/document-templates/components/invoiceDocument.tsx
@@ -17,7 +17,7 @@ import {
     TableRowWithNoBorder,
     TableRowWithTopBorder,
 } from './shared/utils';
-import { formatNumberAsCurrency, getVAT } from '../../lib/pricingUtils';
+import { formatCurrency, getVAT } from '../../lib/pricingUtils';
 import currency from 'currency.js';
 
 const styles = StyleSheet.create({
@@ -62,13 +62,13 @@ const InvoiceRow: React.FC<InvoiceRowProps> = ({ invoiceRow }: InvoiceRowProps) 
                         <Text>{`${pricedInvoiceRow.numberOfUnits}${pricedInvoiceRow.unit}`}</Text>
                     </TableCellFixedWidth>
                     <TableCellFixedWidth width={90} textAlign="right">
-                        <Text>{formatNumberAsCurrency(pricedInvoiceRow.pricePerUnit)}</Text>
+                        <Text>{formatCurrency(pricedInvoiceRow.pricePerUnit)}</Text>
                     </TableCellFixedWidth>
                     <TableCellFixedWidth width={90} textAlign="right">
                         <Text>{pricedInvoiceRow.account}</Text>
                     </TableCellFixedWidth>
                     <TableCellFixedWidth width={90} textAlign="right">
-                        <Text>{formatNumberAsCurrency(pricedInvoiceRow.rowPrice)}</Text>
+                        <Text>{formatCurrency(pricedInvoiceRow.rowPrice)}</Text>
                     </TableCellFixedWidth>
                 </TableRowWithTopBorder>
             );
@@ -96,7 +96,7 @@ const AccountRows: React.FC<AccountRowsProps> = ({ invoiceData }: AccountRowsPro
                         <Text>{`${t('invoice.account')}: ${key}`}</Text>
                     </TableCellAutoWidth>
                     <TableCellFixedWidth width={90} textAlign="right">
-                        <Text>{formatNumberAsCurrency(calculateRowPriceSum(rowsByAccount[key]))}</Text>
+                        <Text>{formatCurrency(calculateRowPriceSum(rowsByAccount[key]))}</Text>
                     </TableCellFixedWidth>
                 </TableRow>
             ))}
@@ -124,7 +124,7 @@ const InvoiceTotalPriceSection: React.FC<InvoiceTotalPriceSectionProps> = ({
                     <Text style={styles.bold}>{t('invoice.total-price-section.total-sum-ex-vat')}</Text>
                 </TableCellAutoWidth>
                 <TableCellFixedWidth width={90} textAlign="right">
-                    <Text style={styles.bold}>{formatNumberAsCurrency(calculateTotalAmount(invoiceData))}</Text>
+                    <Text style={styles.bold}>{formatCurrency(calculateTotalAmount(invoiceData))}</Text>
                 </TableCellFixedWidth>
             </TableRow>
 
@@ -133,7 +133,7 @@ const InvoiceTotalPriceSection: React.FC<InvoiceTotalPriceSectionProps> = ({
                     <Text>{t('invoice.total-price-section.vat')}</Text>
                 </TableCellAutoWidth>
                 <TableCellFixedWidth width={90} textAlign="right">
-                    <Text>{formatNumberAsCurrency(calculateTotalVAT(invoiceData))}</Text>
+                    <Text>{formatCurrency(calculateTotalVAT(invoiceData))}</Text>
                 </TableCellFixedWidth>
             </TableRow>
 
@@ -143,7 +143,7 @@ const InvoiceTotalPriceSection: React.FC<InvoiceTotalPriceSectionProps> = ({
                 </TableCellAutoWidth>
                 <TableCellFixedWidth width={90} textAlign="right">
                     <Text style={styles.bold}>
-                        {formatNumberAsCurrency(calculateTotalAmount(invoiceData).add(calculateTotalVAT(invoiceData)))}
+                        {formatCurrency(calculateTotalAmount(invoiceData).add(calculateTotalVAT(invoiceData)))}
                     </Text>
                 </TableCellFixedWidth>
             </TableRow>

--- a/src/document-templates/components/salaryReportDocument.tsx
+++ b/src/document-templates/components/salaryReportDocument.tsx
@@ -7,7 +7,7 @@ import { MainContent } from './shared/mainContent';
 import { SalaryReport } from '../../models/misc/Salary';
 import { Footer } from './shared/footer';
 import { TableRow, TableCellAutoWidth, TableCellFixedWidth, Col, InfoItem } from './shared/utils';
-import { formatNumberAsCurrency } from '../../lib/pricingUtils';
+import { formatCurrency, formatNumberAsCurrency } from '../../lib/pricingUtils';
 import { KeyValue } from '../../models/interfaces/KeyValue';
 
 type Props = {
@@ -94,7 +94,7 @@ export const SalaryReportDocument: React.FC<Props> = ({ salaryReport, globalSett
                                         <Text>{formatNumberAsCurrency(line.hourlyRate)}</Text>
                                     </TableCellFixedWidth>
                                     <TableCellFixedWidth width={70} textAlign="right">
-                                        <Text>{formatNumberAsCurrency(line.sum)}</Text>
+                                        <Text>{formatCurrency(line.sum)}</Text>
                                     </TableCellFixedWidth>
                                 </TableRow>
                             ))}
@@ -104,7 +104,7 @@ export const SalaryReportDocument: React.FC<Props> = ({ salaryReport, globalSett
                                     <Text style={styles.bold}>Totalt att betala SEK</Text>
                                 </TableCellAutoWidth>
                                 <TableCellFixedWidth width={90} textAlign="right">
-                                    <Text style={styles.bold}>{formatNumberAsCurrency(userSalaryReport.sum)}</Text>
+                                    <Text style={styles.bold}>{formatCurrency(userSalaryReport.sum)}</Text>
                                 </TableCellFixedWidth>
                             </TableRow>
                         </View>

--- a/src/document-templates/components/shared/equipmentListInfo.tsx
+++ b/src/document-templates/components/shared/equipmentListInfo.tsx
@@ -59,13 +59,13 @@ export const EquipmentListInfo: React.FC<Props> = ({ list, booking, showPrices }
                 </TableCellFixedWidth>
                 {showPrices ? (
                     <>
-                        <TableCellFixedWidth width={90} textAlign="right">
+                        <TableCellFixedWidth width={110} textAlign="right">
                             <Text style={styles.italic}>{t('common.equipment-list.table-header.price')}</Text>
                         </TableCellFixedWidth>
-                        <TableCellFixedWidth width={90} textAlign="right">
+                        <TableCellFixedWidth width={80} textAlign="right">
                             <Text style={styles.italic}>{t('common.equipment-list.table-header.discount')}</Text>
                         </TableCellFixedWidth>
-                        <TableCellFixedWidth width={90} textAlign="right">
+                        <TableCellFixedWidth width={80} textAlign="right">
                             <Text style={styles.italic}>{t('common.equipment-list.table-header.total-price')}</Text>
                         </TableCellFixedWidth>
                     </>
@@ -92,7 +92,7 @@ export const EquipmentListInfo: React.FC<Props> = ({ list, booking, showPrices }
                                 </TableCellFixedWidth>
                                 {showPrices ? (
                                     <>
-                                        <TableCellFixedWidth width={90} textAlign="right">
+                                        <TableCellFixedWidth width={110} textAlign="right">
                                             {!isHeading ? (
                                                 <Text>{formatEquipmentListEntryPriceWithVAT(entry, t)}</Text>
                                             ) : (
@@ -110,7 +110,7 @@ export const EquipmentListInfo: React.FC<Props> = ({ list, booking, showPrices }
                                                 </Text>
                                             )}
                                         </TableCellFixedWidth>
-                                        <TableCellFixedWidth width={90} textAlign="right">
+                                        <TableCellFixedWidth width={80} textAlign="right">
                                             {!isHeading ? (
                                                 <Text>
                                                     {getCalculatedDiscount(entry, getNumberOfDays(list)).value > 0
@@ -123,7 +123,7 @@ export const EquipmentListInfo: React.FC<Props> = ({ list, booking, showPrices }
                                                 </Text>
                                             ) : null}
                                         </TableCellFixedWidth>
-                                        <TableCellFixedWidth width={90} textAlign="right">
+                                        <TableCellFixedWidth width={80} textAlign="right">
                                             {!isHeading ? (
                                                 <Text>
                                                     {formatCurrency(addVAT(getPrice(entry, getNumberOfDays(list))))}

--- a/src/document-templates/components/shared/equipmentListInfo.tsx
+++ b/src/document-templates/components/shared/equipmentListInfo.tsx
@@ -3,12 +3,13 @@ import React from 'react';
 import { commonStyles, formatEquipmentListEntryCountOrHours, formatEquipmentListEntryPriceWithVAT } from '../../utils';
 import { EquipmentList, EquipmentListEntry, EquipmentListHeading } from '../../../models/interfaces/EquipmentList';
 import {
-    formatNumberAsCurrency,
     getPrice,
     getEquipmentListPrice,
     getEquipmentListHeadingPrice,
     getCalculatedDiscount,
     addVAT,
+    convertPriceToCurrency,
+    formatCurrency,
 } from '../../../lib/pricingUtils';
 import { TableRow, TableCellAutoWidth, TableCellFixedWidth } from './utils';
 import { useTextResources } from '../../useTextResources';
@@ -16,6 +17,7 @@ import { getNumberOfDays } from '../../../lib/datetimeUtils';
 import { Booking } from '../../../models/interfaces';
 import { EquipmentListDateInfo } from './equipmentListDateInfo';
 import { getSortedList } from '../../../lib/sortIndexUtils';
+import currency from 'currency.js';
 
 const styles = StyleSheet.create({
     ...commonStyles,
@@ -80,8 +82,7 @@ export const EquipmentListInfo: React.FC<Props> = ({ list, booking, showPrices }
                         <>
                             <TableRow key={wrappedEntry.id + wrappedEntry.typeIdentifier}>
                                 <TableCellAutoWidth>
-                                    <Text>{wrappedEntry.entity.name}</Text>
-                                    <Text style={{ color: '#999999' }}>{wrappedEntry.entity.description}</Text>
+                                <Text>{wrappedEntry.entity.description}</Text>
                                 </TableCellAutoWidth>
                                 <TableCellFixedWidth width={90} textAlign="right">
                                     {!isHeading ? (
@@ -94,7 +95,7 @@ export const EquipmentListInfo: React.FC<Props> = ({ list, booking, showPrices }
                                     <>
                                         <TableCellFixedWidth width={90} textAlign="right">
                                             {!isHeading ? (
-                                                <Text>{formatEquipmentListEntryPriceWithVAT(entry, t)}</Text>
+                                                <Text>{formatEquipmentListEntryPriceWithVAT(convertPriceToCurrency(entry), t)}</Text>
                                             ) : (
                                                 <Text>
                                                     {formatEquipmentListEntryPriceWithVAT(
@@ -103,7 +104,7 @@ export const EquipmentListInfo: React.FC<Props> = ({ list, booking, showPrices }
                                                                 heading,
                                                                 getNumberOfDays(list),
                                                             ),
-                                                            pricePerHour: 0,
+                                                            pricePerHour: currency(0),
                                                         },
                                                         t,
                                                     )}
@@ -114,7 +115,7 @@ export const EquipmentListInfo: React.FC<Props> = ({ list, booking, showPrices }
                                             {!isHeading ? (
                                                 <Text>
                                                     {getCalculatedDiscount(entry, getNumberOfDays(list)).value > 0
-                                                        ? formatNumberAsCurrency(
+                                                        ? formatCurrency(
                                                               addVAT(
                                                                   getCalculatedDiscount(entry, getNumberOfDays(list)),
                                                               ),
@@ -126,13 +127,13 @@ export const EquipmentListInfo: React.FC<Props> = ({ list, booking, showPrices }
                                         <TableCellFixedWidth width={90} textAlign="right">
                                             {!isHeading ? (
                                                 <Text>
-                                                    {formatNumberAsCurrency(
+                                                    {formatCurrency(
                                                         addVAT(getPrice(entry, getNumberOfDays(list))),
                                                     )}
                                                 </Text>
                                             ) : (
                                                 <Text>
-                                                    {formatNumberAsCurrency(
+                                                    {formatCurrency(
                                                         addVAT(
                                                             getEquipmentListHeadingPrice(
                                                                 heading,
@@ -158,7 +159,7 @@ export const EquipmentListInfo: React.FC<Props> = ({ list, booking, showPrices }
                         </TableCellAutoWidth>
                         <TableCellFixedWidth width={90} textAlign="right">
                             <Text style={styles.bold}>
-                                {formatNumberAsCurrency(addVAT(getEquipmentListPrice(list)))}
+                                {formatCurrency(addVAT(getEquipmentListPrice(list)))}
                             </Text>
                         </TableCellFixedWidth>
                     </TableRow>

--- a/src/document-templates/components/shared/equipmentListInfo.tsx
+++ b/src/document-templates/components/shared/equipmentListInfo.tsx
@@ -81,7 +81,7 @@ export const EquipmentListInfo: React.FC<Props> = ({ list, booking, showPrices }
                         <>
                             <TableRow key={wrappedEntry.id + wrappedEntry.typeIdentifier}>
                                 <TableCellAutoWidth>
-                                <Text>{wrappedEntry.entity.description}</Text>
+                                    <Text>{wrappedEntry.entity.description}</Text>
                                 </TableCellAutoWidth>
                                 <TableCellFixedWidth width={90} textAlign="right">
                                     {!isHeading ? (
@@ -94,7 +94,7 @@ export const EquipmentListInfo: React.FC<Props> = ({ list, booking, showPrices }
                                     <>
                                         <TableCellFixedWidth width={90} textAlign="right">
                                             {!isHeading ? (
-                                                <Text>{formatEquipmentListEntryPriceWithVAT((entry), t)}</Text>
+                                                <Text>{formatEquipmentListEntryPriceWithVAT(entry, t)}</Text>
                                             ) : (
                                                 <Text>
                                                     {formatEquipmentListEntryPriceWithVAT(
@@ -126,9 +126,7 @@ export const EquipmentListInfo: React.FC<Props> = ({ list, booking, showPrices }
                                         <TableCellFixedWidth width={90} textAlign="right">
                                             {!isHeading ? (
                                                 <Text>
-                                                    {formatCurrency(
-                                                        addVAT(getPrice(entry, getNumberOfDays(list))),
-                                                    )}
+                                                    {formatCurrency(addVAT(getPrice(entry, getNumberOfDays(list))))}
                                                 </Text>
                                             ) : (
                                                 <Text>
@@ -157,9 +155,7 @@ export const EquipmentListInfo: React.FC<Props> = ({ list, booking, showPrices }
                             <Text style={styles.bold}>{t('common.equipment-list.total')}</Text>
                         </TableCellAutoWidth>
                         <TableCellFixedWidth width={90} textAlign="right">
-                            <Text style={styles.bold}>
-                                {formatCurrency(addVAT(getEquipmentListPrice(list)))}
-                            </Text>
+                            <Text style={styles.bold}>{formatCurrency(addVAT(getEquipmentListPrice(list)))}</Text>
                         </TableCellFixedWidth>
                     </TableRow>
                 </>

--- a/src/document-templates/components/shared/equipmentListInfo.tsx
+++ b/src/document-templates/components/shared/equipmentListInfo.tsx
@@ -8,7 +8,6 @@ import {
     getEquipmentListHeadingPrice,
     getCalculatedDiscount,
     addVAT,
-    convertPriceToCurrency,
     formatCurrency,
 } from '../../../lib/pricingUtils';
 import { TableRow, TableCellAutoWidth, TableCellFixedWidth } from './utils';
@@ -95,7 +94,7 @@ export const EquipmentListInfo: React.FC<Props> = ({ list, booking, showPrices }
                                     <>
                                         <TableCellFixedWidth width={90} textAlign="right">
                                             {!isHeading ? (
-                                                <Text>{formatEquipmentListEntryPriceWithVAT(convertPriceToCurrency(entry), t)}</Text>
+                                                <Text>{formatEquipmentListEntryPriceWithVAT((entry), t)}</Text>
                                             ) : (
                                                 <Text>
                                                     {formatEquipmentListEntryPriceWithVAT(

--- a/src/document-templates/components/shared/timeEstimateListInfo.tsx
+++ b/src/document-templates/components/shared/timeEstimateListInfo.tsx
@@ -2,10 +2,10 @@ import { View, Text, StyleSheet } from '@react-pdf/renderer';
 import React from 'react';
 import { commonStyles } from '../../utils';
 import {
-    formatNumberAsCurrency,
     getTimeEstimatePrice,
     getTotalTimeEstimatesPrice,
     addVAT,
+    formatCurrency,
 } from '../../../lib/pricingUtils';
 import { TableRow, TableCellAutoWidth, TableCellFixedWidth } from './utils';
 import { useTextResources } from '../../useTextResources';
@@ -64,10 +64,10 @@ export const TimeEstimateListInfo: React.FC<Props> = ({ booking, showPrices }: P
                         {showPrices ? (
                             <>
                                 <TableCellFixedWidth width={90} textAlign="right">
-                                    <Text>{formatNumberAsCurrency(addVAT(timeEstimate.pricePerHour))}</Text>
+                                    <Text>{formatCurrency(addVAT(timeEstimate.pricePerHour))}</Text>
                                 </TableCellFixedWidth>
                                 <TableCellFixedWidth width={180} textAlign="right">
-                                    <Text>{formatNumberAsCurrency(addVAT(getTimeEstimatePrice(timeEstimate)))}</Text>
+                                    <Text>{formatCurrency(addVAT(getTimeEstimatePrice(timeEstimate)))}</Text>
                                 </TableCellFixedWidth>
                             </>
                         ) : null}
@@ -82,7 +82,7 @@ export const TimeEstimateListInfo: React.FC<Props> = ({ booking, showPrices }: P
                         </TableCellAutoWidth>
                         <TableCellFixedWidth width={90} textAlign="right">
                             <Text style={styles.bold}>
-                                {formatNumberAsCurrency(addVAT(getTotalTimeEstimatesPrice(booking.timeEstimates)))}
+                                {formatCurrency(addVAT(getTotalTimeEstimatesPrice(booking.timeEstimates)))}
                             </Text>
                         </TableCellFixedWidth>
                     </TableRow>

--- a/src/document-templates/components/shared/timeEstimateListInfo.tsx
+++ b/src/document-templates/components/shared/timeEstimateListInfo.tsx
@@ -1,12 +1,7 @@
 import { View, Text, StyleSheet } from '@react-pdf/renderer';
 import React from 'react';
 import { commonStyles } from '../../utils';
-import {
-    getTimeEstimatePrice,
-    getTotalTimeEstimatesPrice,
-    addVAT,
-    formatCurrency,
-} from '../../../lib/pricingUtils';
+import { getTimeEstimatePrice, getTotalTimeEstimatesPrice, addVAT, formatCurrency } from '../../../lib/pricingUtils';
 import { TableRow, TableCellAutoWidth, TableCellFixedWidth } from './utils';
 import { useTextResources } from '../../useTextResources';
 import { Booking } from '../../../models/interfaces';

--- a/src/document-templates/components/shared/timeEstimateListInfo.tsx
+++ b/src/document-templates/components/shared/timeEstimateListInfo.tsx
@@ -35,10 +35,10 @@ export const TimeEstimateListInfo: React.FC<Props> = ({ booking, showPrices }: P
                 </TableCellFixedWidth>
                 {showPrices ? (
                     <>
-                        <TableCellFixedWidth width={90} textAlign="right">
+                        <TableCellFixedWidth width={110} textAlign="right">
                             <Text style={styles.italic}>{t('common.time-estimate-list.table-header.price')}</Text>
                         </TableCellFixedWidth>
-                        <TableCellFixedWidth width={180} textAlign="right">
+                        <TableCellFixedWidth width={160} textAlign="right">
                             <Text style={styles.italic}>{t('common.time-estimate-list.table-header.total-price')}</Text>
                         </TableCellFixedWidth>
                     </>
@@ -58,10 +58,10 @@ export const TimeEstimateListInfo: React.FC<Props> = ({ booking, showPrices }: P
                         </TableCellFixedWidth>
                         {showPrices ? (
                             <>
-                                <TableCellFixedWidth width={90} textAlign="right">
+                                <TableCellFixedWidth width={110} textAlign="right">
                                     <Text>{formatCurrency(addVAT(timeEstimate.pricePerHour))}</Text>
                                 </TableCellFixedWidth>
-                                <TableCellFixedWidth width={180} textAlign="right">
+                                <TableCellFixedWidth width={160} textAlign="right">
                                     <Text>{formatCurrency(addVAT(getTimeEstimatePrice(timeEstimate)))}</Text>
                                 </TableCellFixedWidth>
                             </>

--- a/src/document-templates/components/shared/totalPriceSection.tsx
+++ b/src/document-templates/components/shared/totalPriceSection.tsx
@@ -60,9 +60,7 @@ export const TotalPriceSection: React.FC<Props> = ({
                             <Text>{t('common.total-price-section.time-estimate-sum')}</Text>
                         </TableCellAutoWidth>
                         <TableCellFixedWidth width={90} textAlign="right">
-                            <Text>
-                                {formatCurrency(addVAT(getTotalTimeEstimatesPrice(booking.timeEstimates)))}
-                            </Text>
+                            <Text>{formatCurrency(addVAT(getTotalTimeEstimatesPrice(booking.timeEstimates)))}</Text>
                         </TableCellFixedWidth>
                     </TableRow>
                 ) : null}

--- a/src/document-templates/components/shared/totalPriceSection.tsx
+++ b/src/document-templates/components/shared/totalPriceSection.tsx
@@ -2,12 +2,12 @@ import { View, Text, StyleSheet } from '@react-pdf/renderer';
 import React from 'react';
 import { commonStyles } from '../../utils';
 import {
-    formatNumberAsCurrency,
     getEquipmentListPrice,
     getBookingPrice,
     getTotalTimeEstimatesPrice,
     addVAT,
     getVAT,
+    formatCurrency,
 } from '../../../lib/pricingUtils';
 import { TableRow, TableCellAutoWidth, TableCellFixedWidth } from './utils';
 import { Booking } from '../../../models/interfaces';
@@ -49,7 +49,7 @@ export const TotalPriceSection: React.FC<Props> = ({
                                   <Text>{list.name}</Text>
                               </TableCellAutoWidth>
                               <TableCellFixedWidth width={90} textAlign="right">
-                                  <Text>{formatNumberAsCurrency(addVAT(getEquipmentListPrice(list)))}</Text>
+                                  <Text>{formatCurrency(addVAT(getEquipmentListPrice(list)))}</Text>
                               </TableCellFixedWidth>
                           </TableRow>
                       ))
@@ -61,7 +61,7 @@ export const TotalPriceSection: React.FC<Props> = ({
                         </TableCellAutoWidth>
                         <TableCellFixedWidth width={90} textAlign="right">
                             <Text>
-                                {formatNumberAsCurrency(addVAT(getTotalTimeEstimatesPrice(booking.timeEstimates)))}
+                                {formatCurrency(addVAT(getTotalTimeEstimatesPrice(booking.timeEstimates)))}
                             </Text>
                         </TableCellFixedWidth>
                     </TableRow>
@@ -79,7 +79,7 @@ export const TotalPriceSection: React.FC<Props> = ({
                     </Text>
                 </TableCellAutoWidth>
                 <TableCellFixedWidth width={90} textAlign="right">
-                    <Text style={styles.bold}>{formatNumberAsCurrency(addVAT(getBookingPrice(booking, true)))}</Text>
+                    <Text style={styles.bold}>{formatCurrency(addVAT(getBookingPrice(booking, true)))}</Text>
                 </TableCellFixedWidth>
             </TableRow>
 
@@ -88,7 +88,7 @@ export const TotalPriceSection: React.FC<Props> = ({
                     <Text style={styles.bold}>{t('common.total-price-section.vat')}</Text>
                 </TableCellAutoWidth>
                 <TableCellFixedWidth width={90} textAlign="right">
-                    <Text style={styles.bold}>{formatNumberAsCurrency(getVAT(getBookingPrice(booking, true)))}</Text>
+                    <Text style={styles.bold}>{formatCurrency(getVAT(getBookingPrice(booking, true)))}</Text>
                 </TableCellFixedWidth>
             </TableRow>
         </View>

--- a/src/document-templates/txt/hogiaInvoice.tsx
+++ b/src/document-templates/txt/hogiaInvoice.tsx
@@ -24,7 +24,7 @@ export const getHogiaTxtInvoice = (invoiceData: InvoiceData, t: (key: string) =>
         };
 
         const getRowFormat = (): Map<number, string> => {
-            const currencyFormatOptions = { decimal: ',', symbol: '', separator: '' }
+            const currencyFormatOptions = { decimal: ',', symbol: '', separator: '' };
             switch (invoiceRow.rowType) {
                 case InvoiceRowType.ITEM:
                     const pricedInvoiceRow = invoiceRow as PricedInvoiceRow;

--- a/src/document-templates/utils.ts
+++ b/src/document-templates/utils.ts
@@ -1,7 +1,7 @@
 import { Font, StyleSheet } from '@react-pdf/renderer';
 import { getNumberOfDays } from '../lib/datetimeUtils';
 import { Booking } from '../models/interfaces';
-import { PricedEntityCurrency } from '../models/interfaces/BaseEntity';
+import { PricedEntity } from '../models/interfaces/BaseEntity';
 import { EquipmentListEntry } from '../models/interfaces/EquipmentList';
 import { addVATToPrice, formatPrice } from '../lib/pricingUtils';
 import { KeyValue } from '../models/interfaces/KeyValue';
@@ -120,7 +120,7 @@ export const formatEquipmentListEntryCountOrHours = (entry: EquipmentListEntry, 
     return formatEquipmentListEntryCount(entry, t);
 };
 
-export const formatEquipmentListEntryPriceWithVAT = (entry: PricedEntityCurrency, t: (t: string) => string) =>
+export const formatEquipmentListEntryPriceWithVAT = (entry: PricedEntity, t: (t: string) => string) =>
     formatPrice(addVATToPrice(entry), t('common.misc.hours-unit'), t('common.misc.count-unit-single'));
 
 export const allListsAreOneDay = (booking: Booking) =>

--- a/src/document-templates/utils.ts
+++ b/src/document-templates/utils.ts
@@ -1,7 +1,7 @@
 import { Font, StyleSheet } from '@react-pdf/renderer';
 import { getNumberOfDays } from '../lib/datetimeUtils';
 import { Booking } from '../models/interfaces';
-import { PricedEntity } from '../models/interfaces/BaseEntity';
+import { PricedEntityCurrency } from '../models/interfaces/BaseEntity';
 import { EquipmentListEntry } from '../models/interfaces/EquipmentList';
 import { addVATToPrice, formatPrice } from '../lib/pricingUtils';
 import { KeyValue } from '../models/interfaces/KeyValue';
@@ -120,7 +120,7 @@ export const formatEquipmentListEntryCountOrHours = (entry: EquipmentListEntry, 
     return formatEquipmentListEntryCount(entry, t);
 };
 
-export const formatEquipmentListEntryPriceWithVAT = (entry: PricedEntity, t: (t: string) => string) =>
+export const formatEquipmentListEntryPriceWithVAT = (entry: PricedEntityCurrency, t: (t: string) => string) =>
     formatPrice(addVATToPrice(entry), t('common.misc.hours-unit'), t('common.misc.count-unit-single'));
 
 export const allListsAreOneDay = (booking: Booking) =>

--- a/src/lib/db-access/equipmentListEntry.ts
+++ b/src/lib/db-access/equipmentListEntry.ts
@@ -116,6 +116,13 @@ export const validateEquipmentListEntryObjectionModel = (
     ) {
         return false;
     }
+
+    if (
+        equipmentListEntry.discount !== undefined &&
+        (isNaN(equipmentListEntry.discount) || equipmentListEntry.discount < 0)
+    ) {
+        return false;
+    }
     // Both relations (heading and list) cannot be null.
     if (
         equipmentListEntry.equipmentListId === null &&

--- a/src/lib/equipmentListUtils.ts
+++ b/src/lib/equipmentListUtils.ts
@@ -19,6 +19,7 @@ import { getNextSortIndex, moveItemUp, moveItemDown, getSortedList } from './sor
 import { ITimeEstimateObjectionModel } from '../models/objection-models';
 import { toTimeEstimate } from './mappers/timeEstimate';
 import { EquipmentPackageEntry } from '../models/interfaces/EquipmentPackage';
+import currency from 'currency.js';
 
 // EquipmentListEntityViewModel and helpers
 //
@@ -117,7 +118,7 @@ export const getDefaultListEntryFromEquipment = (
     }
 
     const prices = isFree
-        ? { pricePerHour: 0, pricePerUnit: 0 }
+        ? { pricePerHour: currency(0), pricePerUnit: currency(0) }
         : getEquipmentListEntryPrices(equipment.prices[0], pricePlan);
 
     const entry: EquipmentListEntry = {
@@ -126,10 +127,10 @@ export const getDefaultListEntryFromEquipment = (
         equipment: equipment,
         equipmentId: equipment.id,
         numberOfUnits: 1,
-        numberOfHours: prices.pricePerHour > 0 ? 1 : 0,
+        numberOfHours: prices.pricePerHour.value > 0 ? 1 : 0,
         name: language === Language.SV ? equipment.name : equipment.nameEN,
         description: language === Language.SV ? equipment.description : equipment.descriptionEN,
-        discount: 0,
+        discount: currency(0),
         isHidden: false,
         account: null,
         ...prices,

--- a/src/lib/mappers/booking.ts
+++ b/src/lib/mappers/booking.ts
@@ -14,6 +14,7 @@ import { toTimeEstimate } from './timeEstimate';
 import { BookingChangelogEntry } from '../../models/interfaces/ChangeLogEntry';
 import { toTimeReport } from './timeReport';
 import { toDatetimeOrUndefined } from '../datetimeUtils';
+import currency from 'currency.js';
 
 export const toBooking = (objectionModel: IBookingObjectionModel): Booking => {
     if (!objectionModel.id) {
@@ -82,6 +83,9 @@ export const toEquipmentListEntry = (objectionModel: IEquipmentListEntryObjectio
         equipment: objectionModel.equipment ? toEquipment(objectionModel.equipment) : undefined,
         equipmentId: objectionModel.equipmentId,
         equipmentPrice: objectionModel.equipmentPrice ? toEquipmentPrice(objectionModel.equipmentPrice) : undefined,
+        pricePerHour: currency(objectionModel.pricePerHour),
+        pricePerUnit: currency(objectionModel.pricePerUnit),
+        discount: currency(objectionModel.discount),
         updated: toDatetimeOrUndefined(objectionModel.updated),
         created: toDatetimeOrUndefined(objectionModel.created),
     };
@@ -159,5 +163,8 @@ export const toEquipmentListEntryObjectionModel = (
         equipmentId: clientModel.equipment?.id,
         equipmentPrice: undefined,
         equipmentPriceId: clientModel.equipmentPrice?.id ?? null,
+        pricePerHour: clientModel.pricePerHour?.value,
+        pricePerUnit: clientModel.pricePerUnit?.value,
+        discount: clientModel.discount?.value
     };
 };

--- a/src/lib/mappers/booking.ts
+++ b/src/lib/mappers/booking.ts
@@ -165,6 +165,6 @@ export const toEquipmentListEntryObjectionModel = (
         equipmentPriceId: clientModel.equipmentPrice?.id ?? null,
         pricePerHour: clientModel.pricePerHour?.value,
         pricePerUnit: clientModel.pricePerUnit?.value,
-        discount: clientModel.discount?.value
+        discount: clientModel.discount?.value,
     };
 };

--- a/src/lib/mappers/equipment.ts
+++ b/src/lib/mappers/equipment.ts
@@ -11,6 +11,7 @@ import { EquipmentChangelogEntry } from '../../models/interfaces/ChangeLogEntry'
 import { EquipmentPublicCategory } from '../../models/interfaces/EquipmentPublicCategory';
 import { EquipmentLocation } from '../../models/interfaces/EquipmentLocation';
 import { toDatetimeOrUndefined } from '../datetimeUtils';
+import currency from 'currency.js';
 
 export const toEquipment = (objectionModel: IEquipmentObjectionModel): Equipment => {
     if (!objectionModel.id) {
@@ -57,6 +58,10 @@ export const toEquipmentPrice = (objectionModel: IEquipmentPriceObjectionModel):
     return {
         ...objectionModel,
         id: objectionModel.id,
+        pricePerHour: currency(objectionModel.pricePerHour),
+        pricePerUnit: currency(objectionModel.pricePerUnit),
+        pricePerHourTHS: currency(objectionModel.pricePerHourTHS),
+        pricePerUnitTHS: currency(objectionModel.pricePerUnitTHS),
         updated: toDatetimeOrUndefined(objectionModel.updated),
         created: toDatetimeOrUndefined(objectionModel.created),
     };
@@ -112,6 +117,10 @@ export const toEquipmentPriceObjectionModel = (clientModel: EquipmentPrice): Par
 
     return {
         ...clientModel,
+        pricePerHour: clientModel.pricePerHour.value,
+        pricePerUnit: clientModel.pricePerUnit.value,
+        pricePerHourTHS: clientModel.pricePerHourTHS.value,
+        pricePerUnitTHS: clientModel.pricePerUnitTHS.value,
         created: undefined,
         updated: undefined,
     };

--- a/src/lib/mappers/timeEstimate.ts
+++ b/src/lib/mappers/timeEstimate.ts
@@ -1,3 +1,4 @@
+import currency from 'currency.js';
 import { TimeEstimate } from '../../models/interfaces';
 import { ITimeEstimateObjectionModel } from '../../models/objection-models/TimeEstimateObjectionModel';
 import { toDatetimeOrUndefined } from '../datetimeUtils';
@@ -10,6 +11,7 @@ export const toTimeEstimate = (objectionModel: ITimeEstimateObjectionModel): Tim
     return {
         ...objectionModel,
         id: objectionModel.id,
+        pricePerHour: currency(objectionModel.pricePerHour),
         updated: toDatetimeOrUndefined(objectionModel.updated),
         created: toDatetimeOrUndefined(objectionModel.created),
     };

--- a/src/lib/mappers/timeReport.ts
+++ b/src/lib/mappers/timeReport.ts
@@ -1,3 +1,4 @@
+import currency from 'currency.js';
 import { TimeReport } from '../../models/interfaces';
 import { ITimeReportObjectionModel } from '../../models/objection-models/TimeReportObjectionModel';
 import { toDatetimeOrUndefined } from '../datetimeUtils';
@@ -11,6 +12,7 @@ export const toTimeReport = (objectionModel: ITimeReportObjectionModel): TimeRep
     return {
         ...objectionModel,
         id: objectionModel.id,
+        pricePerHour: currency(objectionModel.pricePerHour),
         updated: toDatetimeOrUndefined(objectionModel.updated),
         created: toDatetimeOrUndefined(objectionModel.created),
         startDatetime: toDatetimeOrUndefined(objectionModel.startDatetime),

--- a/src/lib/pricingUtils.ts
+++ b/src/lib/pricingUtils.ts
@@ -1,7 +1,7 @@
 import { PricePlan } from '../models/enums/PricePlan';
 import { AccountKind } from '../models/enums/AccountKind';
 import { Booking, BookingViewModel, TimeEstimate, TimeReport } from '../models/interfaces';
-import { PricedEntityCurrency, PricedEntityWithTHSCurrency } from '../models/interfaces/BaseEntity';
+import { PricedEntity, PricedEntityWithTHS } from '../models/interfaces/BaseEntity';
 import { EquipmentList, EquipmentListEntry, EquipmentListHeading } from '../models/interfaces/EquipmentList';
 import { SalaryGroup } from '../models/interfaces/SalaryGroup';
 import { InvoiceCustomer, InvoiceData, InvoiceRow, InvoiceRowType, PricedInvoiceRow } from '../models/misc/Invoice';
@@ -123,11 +123,11 @@ export const getBookingPrice = (booking: Booking, forceEstimatedTime = false, fo
 export const addVAT = (price: currency | number): currency => currency(price).add(getVAT(price));
 export const getVAT = (price: currency | number): currency => currency(price).multiply(0.25);
 
-export const addVATToPrice = (price: PricedEntityCurrency): PricedEntityCurrency => ({
+export const addVATToPrice = (price: PricedEntity): PricedEntity => ({
     pricePerHour: addVAT(price.pricePerHour),
     pricePerUnit: addVAT(price.pricePerUnit),
 });
-export const addVATToPriceWithTHS = (price: PricedEntityWithTHSCurrency): PricedEntityWithTHSCurrency => ({
+export const addVATToPriceWithTHS = (price: PricedEntityWithTHS): PricedEntityWithTHS => ({
     pricePerHour: addVAT(price.pricePerHour),
     pricePerUnit: addVAT(price.pricePerUnit),
     pricePerHourTHS: addVAT(price.pricePerHourTHS),
@@ -136,7 +136,7 @@ export const addVATToPriceWithTHS = (price: PricedEntityWithTHSCurrency): Priced
 
 // Format price
 //
-export const formatPrice = (price: PricedEntityCurrency, hoursUnit = 'h', unitsUnit = 'st'): string => {
+export const formatPrice = (price: PricedEntity, hoursUnit = 'h', unitsUnit = 'st'): string => {
     if (!price.pricePerHour.value && !price.pricePerUnit.value) {
         return `-`;
     } else if (price.pricePerHour.value && !price.pricePerUnit.value) {
@@ -148,7 +148,7 @@ export const formatPrice = (price: PricedEntityCurrency, hoursUnit = 'h', unitsU
     }
 };
 
-export const formatTHSPrice = (price: PricedEntityWithTHSCurrency): string =>
+export const formatTHSPrice = (price: PricedEntityWithTHS): string =>
     formatPrice({ pricePerHour: price.pricePerHourTHS, pricePerUnit: price.pricePerUnitTHS });
 
 export const formatNumberAsCurrency = (number: number, showPlusIfPositive = false): string =>

--- a/src/lib/pricingUtils.ts
+++ b/src/lib/pricingUtils.ts
@@ -57,7 +57,7 @@ export const getCalculatedDiscount = (entry: EquipmentListEntry, numberOfDays: n
     const priceWithoutDiscount = getPrice(entry, numberOfDays, false);
 
     // The database can contain a discount value larger than the linetotal
-    if (priceWithoutDiscount.value < entry.discount) {
+    if (priceWithoutDiscount.value < entry.discount.value) {
         return priceWithoutDiscount;
     }
 
@@ -132,17 +132,6 @@ export const addVATToPriceWithTHS = (price: PricedEntityWithTHSCurrency): Priced
     pricePerUnit: addVAT(price.pricePerUnit),
     pricePerHourTHS: addVAT(price.pricePerHourTHS),
     pricePerUnitTHS: addVAT(price.pricePerUnitTHS),
-});
-
-export const convertPriceToCurrency = (price: PricedEntity): PricedEntityCurrency => ({
-    pricePerHour: currency(price.pricePerHour),
-    pricePerUnit: currency(price.pricePerUnit),
-});
-export const convertPriceToCurrencyWithTHS = (price: PricedEntityWithTHS): PricedEntityWithTHSCurrency => ({
-    pricePerHour: currency(price.pricePerHour),
-    pricePerUnit: currency(price.pricePerUnit),
-    pricePerHourTHS: currency(price.pricePerHourTHS),
-    pricePerUnitTHS: currency(price.pricePerUnitTHS),
 });
 
 // Format price
@@ -274,7 +263,7 @@ export const getInvoiceData = (
                 if ((numberOfDays > 1 || entry.numberOfHours) && entry.pricePerUnit) {
                     invoiceRows.push({
                         rowType: InvoiceRowType.ITEM_COMMENT,
-                        text: `${t('hogia-invoice.start-cost')}: ${formatNumberAsCurrency(entry.pricePerUnit)}`,
+                        text: `${t('hogia-invoice.start-cost')}: ${formatCurrency(entry.pricePerUnit)}`,
                     });
                 }
 

--- a/src/lib/pricingUtils.ts
+++ b/src/lib/pricingUtils.ts
@@ -286,7 +286,7 @@ export const getInvoiceData = (
                     });
                 }
 
-                if (entry.discount) {
+                if (entry.discount.value) {
                     invoiceRows.push({
                         rowType: InvoiceRowType.ITEM_COMMENT,
                         text: `${t('invoice.discount')}: ${formatCurrency(getCalculatedDiscount(entry, numberOfDays))}`,

--- a/src/lib/pricingUtils.ts
+++ b/src/lib/pricingUtils.ts
@@ -1,7 +1,7 @@
 import { PricePlan } from '../models/enums/PricePlan';
 import { AccountKind } from '../models/enums/AccountKind';
 import { Booking, BookingViewModel, TimeEstimate, TimeReport } from '../models/interfaces';
-import { PricedEntity, PricedEntityCurrency, PricedEntityWithTHS, PricedEntityWithTHSCurrency } from '../models/interfaces/BaseEntity';
+import { PricedEntityCurrency, PricedEntityWithTHSCurrency } from '../models/interfaces/BaseEntity';
 import { EquipmentList, EquipmentListEntry, EquipmentListHeading } from '../models/interfaces/EquipmentList';
 import { SalaryGroup } from '../models/interfaces/SalaryGroup';
 import { InvoiceCustomer, InvoiceData, InvoiceRow, InvoiceRowType, PricedInvoiceRow } from '../models/misc/Invoice';
@@ -152,12 +152,11 @@ export const formatTHSPrice = (price: PricedEntityWithTHSCurrency): string =>
     formatPrice({ pricePerHour: price.pricePerHourTHS, pricePerUnit: price.pricePerUnitTHS });
 
 export const formatNumberAsCurrency = (number: number, showPlusIfPositive = false): string =>
-    formatCurrency(currency(number), showPlusIfPositive)
+    formatCurrency(currency(number), showPlusIfPositive);
 
 export const formatCurrency = (number: currency, showPlusIfPositive = false): string =>
     (showPlusIfPositive && number.value > 0 ? '+' : '') +
     Intl.NumberFormat('sv-SE', { style: 'currency', currency: 'SEK' }).format(number.value);
-
 
 export const getInvoiceData = (
     booking: BookingViewModel,
@@ -290,9 +289,7 @@ export const getInvoiceData = (
                 if (entry.discount) {
                     invoiceRows.push({
                         rowType: InvoiceRowType.ITEM_COMMENT,
-                        text: `${t('invoice.discount')}: ${formatCurrency(
-                            getCalculatedDiscount(entry, numberOfDays),
-                        )}`,
+                        text: `${t('invoice.discount')}: ${formatCurrency(getCalculatedDiscount(entry, numberOfDays))}`,
                     });
                 }
 

--- a/src/models/interfaces/BaseEntity.ts
+++ b/src/models/interfaces/BaseEntity.ts
@@ -18,12 +18,23 @@ export interface HasStringId {
 }
 
 export interface PricedEntity {
-    pricePerHour: number | currency;
-    pricePerUnit: number | currency;
+    pricePerHour: number;
+    pricePerUnit: number;
 }
 export interface PricedEntityWithTHS {
-    pricePerHour: number | currency;
-    pricePerUnit: number | currency;
-    pricePerHourTHS: number | currency;
-    pricePerUnitTHS: number | currency;
+    pricePerHour: number;
+    pricePerUnit: number;
+    pricePerHourTHS: number;
+    pricePerUnitTHS: number;
+}
+
+export interface PricedEntityCurrency {
+    pricePerHour: currency;
+    pricePerUnit: currency;
+}
+export interface PricedEntityWithTHSCurrency {
+    pricePerHour: currency;
+    pricePerUnit: currency;
+    pricePerHourTHS: currency;
+    pricePerUnitTHS: currency;
 }

--- a/src/models/interfaces/BaseEntity.ts
+++ b/src/models/interfaces/BaseEntity.ts
@@ -18,21 +18,10 @@ export interface HasStringId {
 }
 
 export interface PricedEntity {
-    pricePerHour: number;
-    pricePerUnit: number;
-}
-export interface PricedEntityWithTHS {
-    pricePerHour: number;
-    pricePerUnit: number;
-    pricePerHourTHS: number;
-    pricePerUnitTHS: number;
-}
-
-export interface PricedEntityCurrency {
     pricePerHour: currency;
     pricePerUnit: currency;
 }
-export interface PricedEntityWithTHSCurrency {
+export interface PricedEntityWithTHS {
     pricePerHour: currency;
     pricePerUnit: currency;
     pricePerHourTHS: currency;

--- a/src/models/interfaces/EquipmentList.ts
+++ b/src/models/interfaces/EquipmentList.ts
@@ -1,3 +1,4 @@
+import currency from 'currency.js';
 import { EquipmentPrice } from '.';
 import { RentalStatus } from '../enums/RentalStatus';
 import { BaseEntityWithName } from './BaseEntity';
@@ -34,10 +35,10 @@ export interface EquipmentListEntry extends BaseEntityWithName {
     numberOfUnits: number;
     numberOfHours: number;
 
-    pricePerUnit: number;
-    pricePerHour: number;
+    pricePerUnit: currency;
+    pricePerHour: currency;
     equipmentPrice?: EquipmentPrice;
-    discount: number;
+    discount: currency;
     isHidden: boolean;
     account: string | null;
 

--- a/src/models/interfaces/EquipmentPrice.ts
+++ b/src/models/interfaces/EquipmentPrice.ts
@@ -1,8 +1,9 @@
+import currency from 'currency.js';
 import { BaseEntityWithName } from './BaseEntity';
 
 export interface EquipmentPrice extends BaseEntityWithName {
-    pricePerUnit: number;
-    pricePerHour: number;
-    pricePerUnitTHS: number;
-    pricePerHourTHS: number;
+    pricePerUnit: currency;
+    pricePerHour: currency;
+    pricePerUnitTHS: currency;
+    pricePerHourTHS: currency;
 }

--- a/src/models/interfaces/TimeEstimate.ts
+++ b/src/models/interfaces/TimeEstimate.ts
@@ -1,8 +1,9 @@
+import currency from 'currency.js';
 import { BaseEntityWithName } from './BaseEntity';
 
 export interface TimeEstimate extends BaseEntityWithName {
     numberOfHours: number;
     bookingId: number;
-    pricePerHour: number;
+    pricePerHour: currency;
     sortIndex: number;
 }

--- a/src/models/interfaces/TimeReport.ts
+++ b/src/models/interfaces/TimeReport.ts
@@ -1,3 +1,4 @@
+import currency from 'currency.js';
 import { BaseEntityWithName } from './BaseEntity';
 import { User } from './User';
 
@@ -8,7 +9,7 @@ export interface TimeReport extends BaseEntityWithName {
     billableWorkingHours: number;
     startDatetime?: Date;
     endDatetime?: Date;
-    pricePerHour: number;
+    pricePerHour: currency;
     bookingId: number;
     sortIndex: number;
 }

--- a/src/pages/bookings/[id]/index.tsx
+++ b/src/pages/bookings/[id]/index.tsx
@@ -43,7 +43,7 @@ import { PaymentStatus } from '../../../models/enums/PaymentStatus';
 import ChangelogCard from '../../../components/ChangelogCard';
 import {
     addVAT,
-    formatNumberAsCurrency,
+    formatCurrency,
     getBookingPrice,
     getEquipmentListPrice,
     getTotalTimeEstimatesPrice,
@@ -364,29 +364,29 @@ const BookingPage: React.FC<Props> = ({ user: currentUser, globalSettings }: Pro
                             {booking.equipmentLists?.map((list) => (
                                 <ListGroup.Item className="d-flex" key={list.id}>
                                     <span className="flex-grow-1">{list.name}</span>
-                                    <span>{formatNumberAsCurrency(addVAT(getEquipmentListPrice(list)))}</span>
+                                    <span>{formatCurrency(addVAT(getEquipmentListPrice(list)))}</span>
                                 </ListGroup.Item>
                             ))}
                             <ListGroup.Item className="d-flex">
                                 <span className="flex-grow-1">Estimerad personalkostnad</span>
                                 <span>
-                                    {formatNumberAsCurrency(addVAT(getTotalTimeEstimatesPrice(booking.timeEstimates)))}
+                                    {formatCurrency(addVAT(getTotalTimeEstimatesPrice(booking.timeEstimates)))}
                                 </span>
                             </ListGroup.Item>
                             <ListGroup.Item className="d-flex">
                                 <strong className="flex-grow-1">Pris med estimerad personalkostnad</strong>
-                                <strong>{formatNumberAsCurrency(addVAT(getBookingPrice(booking, true, true)))}</strong>
+                                <strong>{formatCurrency(addVAT(getBookingPrice(booking, true, true)))}</strong>
                             </ListGroup.Item>
                             <ListGroup.Item className="d-flex">
                                 <em className="flex-grow-1 pl-4">varav moms (25%)</em>
-                                <em>{formatNumberAsCurrency(getVAT(getBookingPrice(booking, true, true)))}</em>
+                                <em>{formatCurrency(getVAT(getBookingPrice(booking, true, true)))}</em>
                             </ListGroup.Item>
                             {timeReportExists ? (
                                 <>
                                     <ListGroup.Item className="d-flex">
                                         <span className="flex-grow-1">Faktisk personalkostnad</span>
                                         <span>
-                                            {formatNumberAsCurrency(
+                                            {formatCurrency(
                                                 addVAT(getTotalTimeReportsPrice(booking.timeReports)),
                                             )}
                                         </span>
@@ -394,17 +394,17 @@ const BookingPage: React.FC<Props> = ({ user: currentUser, globalSettings }: Pro
                                     <ListGroup.Item className="d-flex">
                                         <strong className="flex-grow-1">Pris med faktisk personalkostnad</strong>
                                         <strong>
-                                            {formatNumberAsCurrency(addVAT(getBookingPrice(booking, false, true)))}
+                                            {formatCurrency(addVAT(getBookingPrice(booking, false, true)))}
                                         </strong>
                                     </ListGroup.Item>
                                     <ListGroup.Item className="d-flex">
                                         <em className="flex-grow-1 pl-4">varav moms (25%)</em>
-                                        <em>{formatNumberAsCurrency(getVAT(getBookingPrice(booking, false, true)))}</em>
+                                        <em>{formatCurrency(getVAT(getBookingPrice(booking, false, true)))}</em>
                                     </ListGroup.Item>
                                     <ListGroup.Item className="d-flex">
                                         <span className="flex-grow-1">Skillnad mot estimerad personalkostnad</span>
                                         <span>
-                                            {formatNumberAsCurrency(
+                                            {formatCurrency(
                                                 addVAT(
                                                     getBookingPrice(booking, false, true).subtract(
                                                         getBookingPrice(booking, true, true),
@@ -420,11 +420,11 @@ const BookingPage: React.FC<Props> = ({ user: currentUser, globalSettings }: Pro
                                 <>
                                     <ListGroup.Item className="d-flex">
                                         <strong className="flex-grow-1">Fast pris</strong>
-                                        <strong>{formatNumberAsCurrency(addVAT(booking.fixedPrice))}</strong>
+                                        <strong>{formatCurrency(addVAT(booking.fixedPrice))}</strong>
                                     </ListGroup.Item>
                                     <ListGroup.Item className="d-flex">
                                         <em className="flex-grow-1 pl-4">varav moms (25%)</em>
-                                        <em>{formatNumberAsCurrency(getVAT(booking.fixedPrice))}</em>
+                                        <em>{formatCurrency(getVAT(booking.fixedPrice))}</em>
                                     </ListGroup.Item>
                                     {timeReportExists ? (
                                         <ListGroup.Item className="d-flex">
@@ -432,7 +432,7 @@ const BookingPage: React.FC<Props> = ({ user: currentUser, globalSettings }: Pro
                                                 Skillnad mot pris med faktisk personalkostnad
                                             </span>
                                             <span>
-                                                {formatNumberAsCurrency(
+                                                {formatCurrency(
                                                     addVAT(
                                                         currency(booking.fixedPrice).subtract(
                                                             getBookingPrice(booking, false, true),
@@ -448,7 +448,7 @@ const BookingPage: React.FC<Props> = ({ user: currentUser, globalSettings }: Pro
                                                 Skillnad mot pris med estimerad personalkostnad
                                             </span>
                                             <span>
-                                                {formatNumberAsCurrency(
+                                                {formatCurrency(
                                                     addVAT(
                                                         currency(booking.fixedPrice).subtract(
                                                             getBookingPrice(booking, true, true),

--- a/src/pages/bookings/[id]/index.tsx
+++ b/src/pages/bookings/[id]/index.tsx
@@ -369,9 +369,7 @@ const BookingPage: React.FC<Props> = ({ user: currentUser, globalSettings }: Pro
                             ))}
                             <ListGroup.Item className="d-flex">
                                 <span className="flex-grow-1">Estimerad personalkostnad</span>
-                                <span>
-                                    {formatCurrency(addVAT(getTotalTimeEstimatesPrice(booking.timeEstimates)))}
-                                </span>
+                                <span>{formatCurrency(addVAT(getTotalTimeEstimatesPrice(booking.timeEstimates)))}</span>
                             </ListGroup.Item>
                             <ListGroup.Item className="d-flex">
                                 <strong className="flex-grow-1">Pris med estimerad personalkostnad</strong>
@@ -386,16 +384,12 @@ const BookingPage: React.FC<Props> = ({ user: currentUser, globalSettings }: Pro
                                     <ListGroup.Item className="d-flex">
                                         <span className="flex-grow-1">Faktisk personalkostnad</span>
                                         <span>
-                                            {formatCurrency(
-                                                addVAT(getTotalTimeReportsPrice(booking.timeReports)),
-                                            )}
+                                            {formatCurrency(addVAT(getTotalTimeReportsPrice(booking.timeReports)))}
                                         </span>
                                     </ListGroup.Item>
                                     <ListGroup.Item className="d-flex">
                                         <strong className="flex-grow-1">Pris med faktisk personalkostnad</strong>
-                                        <strong>
-                                            {formatCurrency(addVAT(getBookingPrice(booking, false, true)))}
-                                        </strong>
+                                        <strong>{formatCurrency(addVAT(getBookingPrice(booking, false, true)))}</strong>
                                     </ListGroup.Item>
                                     <ListGroup.Item className="d-flex">
                                         <em className="flex-grow-1 pl-4">varav moms (25%)</em>

--- a/src/pages/cash-payments.tsx
+++ b/src/pages/cash-payments.tsx
@@ -15,7 +15,7 @@ import TableStyleLink from '../components/utils/TableStyleLink';
 import UserDisplay from '../components/utils/UserDisplay';
 import UserIcon from '../components/utils/UserIcon';
 import { bookingsFetcher } from '../lib/fetchers';
-import { addVAT, formatNumberAsCurrency, getBookingPrice } from '../lib/pricingUtils';
+import { addVAT, formatCurrency, getBookingPrice } from '../lib/pricingUtils';
 import { useNotifications } from '../lib/useNotifications';
 import { useUser } from '../lib/useUser';
 import { getGlobalSetting, getResponseContentOrError } from '../lib/utils';
@@ -144,7 +144,7 @@ const CashPaymentsPage: React.FC<Props> = ({ user: currentUser, globalSettings }
     const BookingPriceDisplayFn = (booking: Booking) => (
         <>
             <span style={{ fontSize: '1.2em' }} className="text-monospace">
-                {formatNumberAsCurrency(addVAT(getBookingPrice(booking)))}
+                {formatCurrency(addVAT(getBookingPrice(booking)))}
             </span>
         </>
     );

--- a/src/pages/equipment/[id]/index.tsx
+++ b/src/pages/equipment/[id]/index.tsx
@@ -11,7 +11,7 @@ import Header from '../../../components/layout/Header';
 import { TwoColLoadingPage } from '../../../components/layout/LoadingPageSkeleton';
 import { equipmentFetcher } from '../../../lib/fetchers';
 import { ErrorPage } from '../../../components/layout/ErrorPage';
-import { addVATToPriceWithTHS, formatPrice, formatTHSPrice } from '../../../lib/pricingUtils';
+import { addVATToPriceWithTHS, convertPriceToCurrencyWithTHS, formatPrice, formatTHSPrice } from '../../../lib/pricingUtils';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faPen } from '@fortawesome/free-solid-svg-icons';
 import EquipmentCalendar from '../../../components/equipment/EquipmentCalendar';
@@ -156,11 +156,11 @@ const UserPage: React.FC<Props> = ({ user: currentUser, globalSettings }: Props)
                                     <span className="d-block">{p.name}</span>
                                     <span className="d-flex text-muted">
                                         <span className="flex-grow-1">{getPricePlanName(PricePlan.EXTERNAL)}</span>
-                                        <span>{formatPrice(addVATToPriceWithTHS(p))}</span>
+                                        <span>{formatPrice(addVATToPriceWithTHS(convertPriceToCurrencyWithTHS(p)))}</span>
                                     </span>
                                     <span className="d-flex text-muted">
                                         <span className="flex-grow-1">{getPricePlanName(PricePlan.THS)}</span>
-                                        <span>{formatTHSPrice(addVATToPriceWithTHS(p))}</span>
+                                        <span>{formatTHSPrice(addVATToPriceWithTHS(convertPriceToCurrencyWithTHS(p)))}</span>
                                     </span>
                                 </ListGroup.Item>
                             ))}

--- a/src/pages/equipment/[id]/index.tsx
+++ b/src/pages/equipment/[id]/index.tsx
@@ -156,11 +156,11 @@ const UserPage: React.FC<Props> = ({ user: currentUser, globalSettings }: Props)
                                     <span className="d-block">{p.name}</span>
                                     <span className="d-flex text-muted">
                                         <span className="flex-grow-1">{getPricePlanName(PricePlan.EXTERNAL)}</span>
-                                        <span>{formatPrice(addVATToPriceWithTHS((p)))}</span>
+                                        <span>{formatPrice(addVATToPriceWithTHS(p))}</span>
                                     </span>
                                     <span className="d-flex text-muted">
                                         <span className="flex-grow-1">{getPricePlanName(PricePlan.THS)}</span>
-                                        <span>{formatTHSPrice(addVATToPriceWithTHS((p)))}</span>
+                                        <span>{formatTHSPrice(addVATToPriceWithTHS(p))}</span>
                                     </span>
                                 </ListGroup.Item>
                             ))}

--- a/src/pages/equipment/[id]/index.tsx
+++ b/src/pages/equipment/[id]/index.tsx
@@ -11,7 +11,7 @@ import Header from '../../../components/layout/Header';
 import { TwoColLoadingPage } from '../../../components/layout/LoadingPageSkeleton';
 import { equipmentFetcher } from '../../../lib/fetchers';
 import { ErrorPage } from '../../../components/layout/ErrorPage';
-import { addVATToPriceWithTHS, convertPriceToCurrencyWithTHS, formatPrice, formatTHSPrice } from '../../../lib/pricingUtils';
+import { addVATToPriceWithTHS, formatPrice, formatTHSPrice } from '../../../lib/pricingUtils';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faPen } from '@fortawesome/free-solid-svg-icons';
 import EquipmentCalendar from '../../../components/equipment/EquipmentCalendar';
@@ -156,11 +156,11 @@ const UserPage: React.FC<Props> = ({ user: currentUser, globalSettings }: Props)
                                     <span className="d-block">{p.name}</span>
                                     <span className="d-flex text-muted">
                                         <span className="flex-grow-1">{getPricePlanName(PricePlan.EXTERNAL)}</span>
-                                        <span>{formatPrice(addVATToPriceWithTHS(convertPriceToCurrencyWithTHS(p)))}</span>
+                                        <span>{formatPrice(addVATToPriceWithTHS((p)))}</span>
                                     </span>
                                     <span className="d-flex text-muted">
                                         <span className="flex-grow-1">{getPricePlanName(PricePlan.THS)}</span>
-                                        <span>{formatTHSPrice(addVATToPriceWithTHS(convertPriceToCurrencyWithTHS(p)))}</span>
+                                        <span>{formatTHSPrice(addVATToPriceWithTHS((p)))}</span>
                                     </span>
                                 </ListGroup.Item>
                             ))}

--- a/src/pages/public/prices.tsx
+++ b/src/pages/public/prices.tsx
@@ -3,7 +3,7 @@ import React, { useState } from 'react';
 import { fetchEquipmentPublicCategoriesPublic, fetchEquipmentsPublic } from '../../lib/db-access';
 import { Button, ButtonGroup, Table } from 'react-bootstrap';
 import EquipmentTagDisplay from '../../components/utils/EquipmentTagDisplay';
-import { addVATToPriceWithTHS, convertPriceToCurrencyWithTHS, formatPrice, formatTHSPrice } from '../../lib/pricingUtils';
+import { addVATToPriceWithTHS, formatPrice, formatTHSPrice } from '../../lib/pricingUtils';
 import { getGlobalSetting, groupBy, replaceEmptyStringWithNull } from '../../lib/utils';
 import { IEquipmentObjectionModel } from '../../models/objection-models';
 import {
@@ -14,6 +14,7 @@ import { getGlobalSettings } from '../../lib/useUser';
 import { KeyValue } from '../../models/interfaces/KeyValue';
 import Image from 'next/image';
 import Link from 'next/link';
+import { toEquipmentPrice } from '../../lib/mappers/equipment';
 
 const containerStyle: React.CSSProperties = {
     margin: 'auto',
@@ -62,8 +63,8 @@ const PriceCells: React.FC<PriceCellsProps> = ({ price, hidePriceType, showWithV
             <td>{hidePriceType ? null : price.name}</td>
             <td>
                 {showThsPrice
-                    ? formatTHSPrice(showWithVat ? addVATToPriceWithTHS(convertPriceToCurrencyWithTHS(price)) : convertPriceToCurrencyWithTHS(price))
-                    : formatPrice(showWithVat ? addVATToPriceWithTHS(convertPriceToCurrencyWithTHS(price)) : convertPriceToCurrencyWithTHS(price))}
+                    ? formatTHSPrice(showWithVat ? addVATToPriceWithTHS(toEquipmentPrice(price)) : toEquipmentPrice(price))
+                    : formatPrice(showWithVat ? addVATToPriceWithTHS(toEquipmentPrice(price)) : toEquipmentPrice(price))}
             </td>
         </>
     ) : (

--- a/src/pages/public/prices.tsx
+++ b/src/pages/public/prices.tsx
@@ -6,15 +6,13 @@ import EquipmentTagDisplay from '../../components/utils/EquipmentTagDisplay';
 import { addVATToPriceWithTHS, formatPrice, formatTHSPrice } from '../../lib/pricingUtils';
 import { getGlobalSetting, groupBy, replaceEmptyStringWithNull } from '../../lib/utils';
 import { IEquipmentObjectionModel } from '../../models/objection-models';
-import {
-    IEquipmentPriceObjectionModel,
-    IEquipmentPublicCategoryObjectionModel,
-} from '../../models/objection-models/EquipmentObjectionModel';
+import { IEquipmentPublicCategoryObjectionModel } from '../../models/objection-models/EquipmentObjectionModel';
 import { getGlobalSettings } from '../../lib/useUser';
 import { KeyValue } from '../../models/interfaces/KeyValue';
 import Image from 'next/image';
 import Link from 'next/link';
 import { toEquipmentPrice } from '../../lib/mappers/equipment';
+import { EquipmentPrice } from '../../models/interfaces';
 
 const containerStyle: React.CSSProperties = {
     margin: 'auto',
@@ -38,7 +36,7 @@ const logoContainerStyle: React.CSSProperties = {
 const pageTitle = 'Prislista';
 
 type PriceCellsProps = {
-    price: IEquipmentPriceObjectionModel;
+    price: EquipmentPrice;
     showWithVat: boolean;
     showThsPrice: boolean;
     hidePriceType?: boolean;
@@ -63,8 +61,8 @@ const PriceCells: React.FC<PriceCellsProps> = ({ price, hidePriceType, showWithV
             <td>{hidePriceType ? null : price.name}</td>
             <td>
                 {showThsPrice
-                    ? formatTHSPrice(showWithVat ? addVATToPriceWithTHS(toEquipmentPrice(price)) : toEquipmentPrice(price))
-                    : formatPrice(showWithVat ? addVATToPriceWithTHS(toEquipmentPrice(price)) : toEquipmentPrice(price))}
+                    ? formatTHSPrice(showWithVat ? addVATToPriceWithTHS(price) : price)
+                    : formatPrice(showWithVat ? addVATToPriceWithTHS(price) : price)}
             </td>
         </>
     ) : (
@@ -192,7 +190,7 @@ const PublicPricePage: React.FC<Props> = ({ equipment, equipmentCategories, glob
                                             </td>
                                             {equipment.prices ? (
                                                 <PriceCells
-                                                    price={equipment.prices[0]}
+                                                    price={toEquipmentPrice(equipment.prices[0])}
                                                     hidePriceType={equipment.prices.length === 1}
                                                     showWithVat={includeVat}
                                                     showThsPrice={showThsPrice}
@@ -203,7 +201,7 @@ const PublicPricePage: React.FC<Props> = ({ equipment, equipmentCategories, glob
                                             equipment.prices.slice(1).map((price) => (
                                                 <tr key={`equipment-${equipment.id}-price-${price.id}`}>
                                                     <PriceCells
-                                                        price={price}
+                                                        price={toEquipmentPrice(price)}
                                                         showWithVat={includeVat}
                                                         showThsPrice={showThsPrice}
                                                     ></PriceCells>

--- a/src/pages/public/prices.tsx
+++ b/src/pages/public/prices.tsx
@@ -3,7 +3,7 @@ import React, { useState } from 'react';
 import { fetchEquipmentPublicCategoriesPublic, fetchEquipmentsPublic } from '../../lib/db-access';
 import { Button, ButtonGroup, Table } from 'react-bootstrap';
 import EquipmentTagDisplay from '../../components/utils/EquipmentTagDisplay';
-import { addVATToPriceWithTHS, formatPrice, formatTHSPrice } from '../../lib/pricingUtils';
+import { addVATToPriceWithTHS, convertPriceToCurrencyWithTHS, formatPrice, formatTHSPrice } from '../../lib/pricingUtils';
 import { getGlobalSetting, groupBy, replaceEmptyStringWithNull } from '../../lib/utils';
 import { IEquipmentObjectionModel } from '../../models/objection-models';
 import {
@@ -62,8 +62,8 @@ const PriceCells: React.FC<PriceCellsProps> = ({ price, hidePriceType, showWithV
             <td>{hidePriceType ? null : price.name}</td>
             <td>
                 {showThsPrice
-                    ? formatTHSPrice(showWithVat ? addVATToPriceWithTHS(price) : price)
-                    : formatPrice(showWithVat ? addVATToPriceWithTHS(price) : price)}
+                    ? formatTHSPrice(showWithVat ? addVATToPriceWithTHS(convertPriceToCurrencyWithTHS(price)) : convertPriceToCurrencyWithTHS(price))
+                    : formatPrice(showWithVat ? addVATToPriceWithTHS(convertPriceToCurrencyWithTHS(price)) : convertPriceToCurrencyWithTHS(price))}
             </td>
         </>
     ) : (

--- a/src/pages/users/[id]/time-reports.tsx
+++ b/src/pages/users/[id]/time-reports.tsx
@@ -16,7 +16,7 @@ import TableStyleLink from '../../../components/utils/TableStyleLink';
 import { getBookingDateHeadingValue, getFormattedInterval, toBookingViewModel } from '../../../lib/datetimeUtils';
 import { getGlobalSetting, groupBy } from '../../../lib/utils';
 import { getSortedList } from '../../../lib/sortIndexUtils';
-import { formatNumberAsCurrency, getSalaryForTimeReport } from '../../../lib/pricingUtils';
+import { formatCurrency, formatNumberAsCurrency, getSalaryForTimeReport } from '../../../lib/pricingUtils';
 import { SalaryStatus } from '../../../models/enums/SalaryStatus';
 import TimeReportHourDisplay from '../../../components/utils/TimeReportHourDisplay';
 import DoneIcon from '../../../components/utils/DoneIcon';
@@ -126,7 +126,7 @@ const TimeReportsPage: React.FC<Props> = ({ user: currentUser, globalSettings }:
 
     const TimeReportHourlyRateDisplayFn = (timeReport: TimeReportViewModel) =>
         formatNumberAsCurrency(timeReport.hourlyRate);
-    const TimeReportSumDisplayFn = (timeReport: TimeReportViewModel) => formatNumberAsCurrency(timeReport.salarySum);
+    const TimeReportSumDisplayFn = (timeReport: TimeReportViewModel) => formatCurrency(timeReport.salarySum);
     const TimeReportSentDisplayFn = (timeReport: TimeReportViewModel) =>
         timeReport.booking.salaryStatus === SalaryStatus.SENT ? <DoneIcon /> : <></>;
 
@@ -218,7 +218,7 @@ const TimeReportsPage: React.FC<Props> = ({ user: currentUser, globalSettings }:
                     <TableDisplay entities={timeReportMonth.timeReports} configuration={tableSettings} />
                     <Card.Footer>
                         Totalt timarvode för perioden:{' '}
-                        {formatNumberAsCurrency(
+                        {formatCurrency(
                             timeReportMonth.timeReports.map((x) => x.salarySum).reduce((a, b) => a.add(b), currency(0)),
                         )}
                     </Card.Footer>


### PR DESCRIPTION
Som @m4reko nämnde skulle det vara fint att sätta currencytypen direkt i mappningslagret från DB-modellen, så det har jag gjort ett försök på här.

Jag tror all funktionalitet ska vara exakt samma, med ett undantag: Det var svårare att snyggt göra absolutbelopp för att undvika att folk skriver in negativa värden, så jag implementerade inte det client-side utan låter server-side-valideringen neka uppdateringar om de innehåller negativa värden. Det är ju inte lika snyggt, men simplare kod och jag tror inte det händer så ofta ändå.