### PR TITLE
Bugfix: Document formatting quickfix

### DIFF
--- a/src/document-templates/components/shared/equipmentListInfo.tsx
+++ b/src/document-templates/components/shared/equipmentListInfo.tsx
@@ -10,7 +10,7 @@ import {
     getCalculatedDiscount,
     addVAT,
 } from '../../../lib/pricingUtils';
-import { TableRow, TableCellAutoWidth, TableCellFixedWidth } from './utils';
+import { TableRow, TableCellAutoWidth, TableCellFixedWidth, TableRowWithNoBorder, TableRowWithTopBorder } from './utils';
 import { useTextResources } from '../../useTextResources';
 import { getNumberOfDays } from '../../../lib/datetimeUtils';
 import { Booking } from '../../../models/interfaces';
@@ -46,10 +46,12 @@ export const EquipmentListInfo: React.FC<Props> = ({ list, booking, showPrices }
 
     return (
         <View style={styles.equipmentListSection}>
-            <Text style={styles.heading}>{list.name}</Text>
-            <EquipmentListDateInfo list={list} booking={booking} />
+            <View style={styles.marginBottom}>
+                <Text style={styles.heading}>{list.name}</Text>
+                <EquipmentListDateInfo list={list} booking={booking} />
+            </View>
 
-            <TableRow>
+            <TableRowWithNoBorder>
                 <TableCellAutoWidth>
                     <Text style={styles.italic}>{t('common.equipment-list.table-header.specification')}</Text>
                 </TableCellAutoWidth>
@@ -58,18 +60,18 @@ export const EquipmentListInfo: React.FC<Props> = ({ list, booking, showPrices }
                 </TableCellFixedWidth>
                 {showPrices ? (
                     <>
-                        <TableCellFixedWidth width={90} textAlign="right">
+                        <TableCellFixedWidth width={110} textAlign="right">
                             <Text style={styles.italic}>{t('common.equipment-list.table-header.price')}</Text>
                         </TableCellFixedWidth>
-                        <TableCellFixedWidth width={90} textAlign="right">
+                        <TableCellFixedWidth width={80} textAlign="right">
                             <Text style={styles.italic}>{t('common.equipment-list.table-header.discount')}</Text>
                         </TableCellFixedWidth>
-                        <TableCellFixedWidth width={90} textAlign="right">
+                        <TableCellFixedWidth width={80} textAlign="right">
                             <Text style={styles.italic}>{t('common.equipment-list.table-header.total-price')}</Text>
                         </TableCellFixedWidth>
                     </>
                 ) : null}
-            </TableRow>
+            </TableRowWithNoBorder>
 
             <View>
                 {sortedListEntriesAndHeadings.map((wrappedEntry) => {
@@ -78,10 +80,9 @@ export const EquipmentListInfo: React.FC<Props> = ({ list, booking, showPrices }
                     const isHeading = wrappedEntry.typeIdentifier === 'H';
                     return (
                         <>
-                            <TableRow key={wrappedEntry.id + wrappedEntry.typeIdentifier}>
+                            <TableRowWithTopBorder key={wrappedEntry.id + wrappedEntry.typeIdentifier}>
                                 <TableCellAutoWidth>
                                     <Text>{wrappedEntry.entity.name}</Text>
-                                    <Text style={{ color: '#999999' }}>{wrappedEntry.entity.description}</Text>
                                 </TableCellAutoWidth>
                                 <TableCellFixedWidth width={90} textAlign="right">
                                     {!isHeading ? (
@@ -92,7 +93,7 @@ export const EquipmentListInfo: React.FC<Props> = ({ list, booking, showPrices }
                                 </TableCellFixedWidth>
                                 {showPrices ? (
                                     <>
-                                        <TableCellFixedWidth width={90} textAlign="right">
+                                        <TableCellFixedWidth width={110} textAlign="right">
                                             {!isHeading ? (
                                                 <Text>{formatEquipmentListEntryPriceWithVAT(entry, t)}</Text>
                                             ) : (
@@ -110,7 +111,7 @@ export const EquipmentListInfo: React.FC<Props> = ({ list, booking, showPrices }
                                                 </Text>
                                             )}
                                         </TableCellFixedWidth>
-                                        <TableCellFixedWidth width={90} textAlign="right">
+                                        <TableCellFixedWidth width={80} textAlign="right">
                                             {!isHeading ? (
                                                 <Text>
                                                     {getCalculatedDiscount(entry, getNumberOfDays(list)).value > 0
@@ -123,7 +124,7 @@ export const EquipmentListInfo: React.FC<Props> = ({ list, booking, showPrices }
                                                 </Text>
                                             ) : null}
                                         </TableCellFixedWidth>
-                                        <TableCellFixedWidth width={90} textAlign="right">
+                                        <TableCellFixedWidth width={80} textAlign="right">
                                             {!isHeading ? (
                                                 <Text>
                                                     {formatNumberAsCurrency(
@@ -145,7 +146,12 @@ export const EquipmentListInfo: React.FC<Props> = ({ list, booking, showPrices }
                                         </TableCellFixedWidth>
                                     </>
                                 ) : null}
-                            </TableRow>
+                            </TableRowWithTopBorder>
+                            <TableRowWithNoBorder>
+                            <TableCellAutoWidth>
+                                    <Text style={{ color: '#999999' }}>{wrappedEntry.entity.description}</Text>
+                                </TableCellAutoWidth>
+                            </TableRowWithNoBorder>
                         </>
                     );
                 })}


### PR DESCRIPTION
Detta är absolut inte en optimal lösning, men en snabb workaround/quickfix på formatteringsproblemet med långa beskrivningar i dokumentexporterna.

Jag har helt enkelt lagt beskrivningen på en egen rad, så kan den bli så bred den vill utan att den överlappar någon annan text.
![image](https://github.com/rneventteknik/backstage2/assets/3681132/e36ee9d9-0afe-483a-b303-b83c6cc9e464)
Långa titlar kommer dock fortfarande vara problematiska såklart, men det är ju ovanligare.