### PR TITLE
Feature: Add public API support

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ DRIVE_ROOT_FOLDER_ID={ID of folder which contains booking folders}
 SLACK_BOT_TOKEN={API token for slack bot, with chat:write access}
 SLACK_CHANNEL_ID={Slack channel to post message to}
 APPLICATION_BASE_URL={Base URL of application when generating links, for example http://localhost:3000}
+
+API_KEYS={JSON list of API keys, for example [{"key": "XXX", "name": "slackbot"}]} (optional, only needed when using backstage2 as an API from an external service)
 ```
 
 ### Version Control

--- a/src/lib/authenticate.ts
+++ b/src/lib/authenticate.ts
@@ -96,3 +96,24 @@ export const getAndVerifyUser = async (req: NextApiRequest & IncomingMessage): P
     // User from cookie is ok, return it and do not change any cookies
     return currentUser;
 };
+
+export const getAndVerifyApiKey = async (req: NextApiRequest & IncomingMessage): Promise<CurrentUserInfo> => {
+    const apiKey = req.headers['x-api-key'];
+    const acceptedApiKeys = JSON.parse(process.env.API_KEYS ?? '[]') as {
+        key: string;
+        name: string;
+    }[];
+
+    const authInformation = acceptedApiKeys.find((x) => x.key === apiKey);
+
+    if (authInformation) {
+        return {
+            isLoggedIn: true,
+            name: authInformation.name,
+            loginDate: Date.now(),
+            role: undefined,
+            userId: undefined,
+        };
+    }
+    return { isLoggedIn: false };
+};

--- a/src/lib/db-access/user.ts
+++ b/src/lib/db-access/user.ts
@@ -42,6 +42,14 @@ export const fetchUser = async (
     return query;
 };
 
+export const fetchUserByNameTagForExternalApi = async (nameTag: string): Promise<UserObjectionModel | undefined> => {
+    ensureDatabaseIsInitialized();
+
+    const query = UserObjectionModel.query().findOne('nameTag', '=', nameTag);
+
+    return query.select('id', 'name', 'memberStatus', 'nameTag', 'slackId');
+};
+
 export const fetchUsers = async (): Promise<UserObjectionModel[]> => {
     ensureDatabaseIsInitialized();
 

--- a/src/pages/api/external/v1/usersByNameTag/[nameTag].ts
+++ b/src/pages/api/external/v1/usersByNameTag/[nameTag].ts
@@ -1,0 +1,34 @@
+import { NextApiRequest, NextApiResponse } from 'next';
+import {
+    respondWithCustomErrorMessage,
+    respondWithEntityNotFoundResponse,
+    respondWithInvalidMethodResponse,
+} from '../../../../../lib/apiResponses';
+import { withApiKeyContext } from '../../../../../lib/sessionContext';
+import { fetchUserByNameTagForExternalApi } from '../../../../../lib/db-access/user';
+import { getValueOrFirst } from '../../../../../lib/utils';
+
+const handler = withApiKeyContext(
+    async (req: NextApiRequest, res: NextApiResponse): Promise<void> => {
+        const userTag = getValueOrFirst(req.query.nameTag) ?? '';
+
+        if (userTag.length === 0) {
+            respondWithEntityNotFoundResponse(res);
+            return;
+        }
+
+        switch (req.method) {
+            case 'GET':
+                await fetchUserByNameTagForExternalApi(userTag)
+                    .then((result) => (result ? res.status(200).json(result) : respondWithEntityNotFoundResponse(res)))
+                    .catch((error) => respondWithCustomErrorMessage(res, error.message));
+
+                return;
+
+            default:
+                respondWithInvalidMethodResponse(res);
+        }
+    },
+);
+
+export default handler;


### PR DESCRIPTION
Add support for public/external APIs. Also includes an example endpoint which fetches user information based on name tags.

Authentication is done with tokens using the `X-API-KEY` header. Serverside the list of accepted tokens are configured as an env. variable called `API_KEYS` using a JSON list.

---

To test the provided example endpoint you need to configure backstage2 to accept a key by configuring the env variable, for example:
```
API_KEYS=[{"key": "15ec21b2-6f93-11ee-b962-0242ac120002", "name": "test"}]
```

You can then call the API with:
```
curl --location 'localhost:3000/api/external/v1/usersByNameTag/AM' \
--header 'X-API-KEY: 15ec21b2-6f93-11ee-b962-0242ac120002'
```

Example:
![image](https://github.com/rneventteknik/backstage2/assets/3681132/904a49ae-1d0d-40a0-acea-1d0172576b97)

---

Related trello card: https://trello.com/c/yG0qDyLC/417-bygg-publikt-api