### PR TITLE
Feature: Change access to settings

### DIFF
--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -103,6 +103,7 @@ const sidebar: React.FC<Props> = ({ currentUser, globalSettings }: Props) => (
             <SidebarLink displayName="Utrustning" link="/equipment" icon={faCube} />
             <SidebarLink displayName="Användare" link="/users" icon={faUsers} />
             <SidebarLink displayName="Statistik" link="/statistics" icon={faChartPie} />
+            <SidebarLink displayName="Inställningar" link="/settings" icon={faCog} />
         </SidebarLinkGroup>
 
         <IfAdmin currentUser={currentUser}>
@@ -110,7 +111,6 @@ const sidebar: React.FC<Props> = ({ currentUser, globalSettings }: Props) => (
                 <SidebarLink displayName="Översikt" link="/admin-overview" icon={faListCheck} />
                 <SidebarLink displayName="Timarvodesunderlag" link="/salary" icon={faMoneyBillWave} />
                 <SidebarLink displayName="Fakturaunderlag" link="/invoices" icon={faFileInvoiceDollar} />
-                <SidebarLink displayName="Inställningar" link="/settings" icon={faCog} />
             </SidebarLinkGroup>
         </IfAdmin>
 

--- a/src/components/settings/BaseEntityWithNamesEditor.tsx
+++ b/src/components/settings/BaseEntityWithNamesEditor.tsx
@@ -17,8 +17,9 @@ type Props<T extends BaseEntityWithName> = {
     apiUrl: string;
     entityName: string;
     entityDisplayName: string;
-    getEditComponent: (x: T, save: (x: T) => void) => React.ReactElement;
+    getEditComponent: (x: T, save: (x: T) => void, readOnly?: boolean) => React.ReactElement;
     sortBySortIndex?: boolean;
+    readonly?: boolean;
 };
 
 const BaseEntityWithNamesEditor = <T extends BaseEntityWithName>({
@@ -28,6 +29,7 @@ const BaseEntityWithNamesEditor = <T extends BaseEntityWithName>({
     fetcher,
     getEditComponent,
     sortBySortIndex = false,
+    readonly = false,
 }: Props<T>): React.ReactElement => {
     const { data, mutate, error, isValidating } = useSwr(apiUrl, fetcher);
     const [entityToDelete, setEntityToDelete] = useState<T | null>(null);
@@ -128,7 +130,7 @@ const BaseEntityWithNamesEditor = <T extends BaseEntityWithName>({
                 }}
                 className="mr-2"
             >
-                Redigera
+                {readonly ? 'Visa detaljer' : 'Redigera'}
             </Button>
             <Button
                 variant="danger"
@@ -136,6 +138,7 @@ const BaseEntityWithNamesEditor = <T extends BaseEntityWithName>({
                 onClick={() => {
                     setEntityToDelete(entity);
                 }}
+                disabled={readonly}
             >
                 Ta bort
             </Button>
@@ -187,6 +190,7 @@ const BaseEntityWithNamesEditor = <T extends BaseEntityWithName>({
                     onClick={() => {
                         setEntityToEdit({} as T);
                     }}
+                    disabled={readonly}
                 >
                     <FontAwesomeIcon icon={faPlus} className="mr-1" /> Lägg till
                 </Button>
@@ -207,9 +211,11 @@ const BaseEntityWithNamesEditor = <T extends BaseEntityWithName>({
 
             <Modal show={entityToEdit !== null} onHide={() => setEntityToEdit(null)}>
                 <Modal.Header closeButton>
-                    <Modal.Title>Redigera {entityToEdit?.name}</Modal.Title>
+                    <Modal.Title>{readonly ? entityToEdit?.name : 'Redigera ' + entityToEdit?.name}</Modal.Title>
                 </Modal.Header>
-                <Modal.Body>{entityToEdit ? getEditComponent(entityToEdit, setEntityToEdit) : null}</Modal.Body>
+                <Modal.Body>
+                    {entityToEdit ? getEditComponent(entityToEdit, setEntityToEdit, readonly) : null}
+                </Modal.Body>
                 <Modal.Footer>
                     <Button variant="secondary" onClick={() => setEntityToEdit(null)}>
                         Avbryt
@@ -226,6 +232,7 @@ const BaseEntityWithNamesEditor = <T extends BaseEntityWithName>({
 
                             setEntityToEdit(null);
                         }}
+                        disabled={readonly}
                     >
                         Spara
                     </Button>

--- a/src/components/settings/CustomerEditor.tsx
+++ b/src/components/settings/CustomerEditor.tsx
@@ -10,9 +10,10 @@ import { FormNumberFieldWithoutScroll } from '../utils/FormNumberFieldWithoutScr
 type Props = {
     entity: Customer;
     save: (x: Customer) => void;
+    readOnly?: boolean;
 };
 
-const CustomerEditor: React.FC<Props> = ({ entity, save }: Props) => {
+const CustomerEditor: React.FC<Props> = ({ entity, save, readOnly = false }: Props) => {
     return (
         <>
             <Form.Group controlId="formName">
@@ -21,6 +22,7 @@ const CustomerEditor: React.FC<Props> = ({ entity, save }: Props) => {
                     required
                     type="text"
                     defaultValue={entity?.name}
+                    readOnly={readOnly}
                     onChange={(e) => save({ ...entity, name: e.target.value })}
                 />
             </Form.Group>
@@ -30,6 +32,7 @@ const CustomerEditor: React.FC<Props> = ({ entity, save }: Props) => {
                     type="number"
                     min="0"
                     value={entity.invoiceHogiaId ?? undefined}
+                    readOnly={readOnly}
                     onChange={(e) =>
                         save({
                             ...entity,
@@ -43,6 +46,7 @@ const CustomerEditor: React.FC<Props> = ({ entity, save }: Props) => {
                 <Form.Control
                     as="textarea"
                     rows={3}
+                    readOnly={readOnly}
                     onChange={(e) => save({ ...entity, invoiceAddress: e.target.value })}
                     defaultValue={entity.invoiceAddress ?? ''}
                 />
@@ -54,6 +58,7 @@ const CustomerEditor: React.FC<Props> = ({ entity, save }: Props) => {
                     as="select"
                     name="pricePlan"
                     defaultValue={entity.pricePlan ?? ''}
+                    readOnly={readOnly}
                     onChange={(e) =>
                         save({
                             ...entity,
@@ -73,6 +78,7 @@ const CustomerEditor: React.FC<Props> = ({ entity, save }: Props) => {
                     as="select"
                     name="accountKind"
                     defaultValue={entity.accountKind ?? ''}
+                    readOnly={readOnly}
                     onChange={(e) =>
                         save({
                             ...entity,
@@ -92,6 +98,7 @@ const CustomerEditor: React.FC<Props> = ({ entity, save }: Props) => {
                     as="select"
                     name="language"
                     defaultValue={entity.language ?? Language.SV}
+                    readOnly={readOnly}
                     onChange={(e) =>
                         save({
                             ...entity,

--- a/src/components/settings/EquipmentLocationEditor.tsx
+++ b/src/components/settings/EquipmentLocationEditor.tsx
@@ -7,9 +7,10 @@ import { FormNumberFieldWithoutScroll } from '../utils/FormNumberFieldWithoutScr
 type Props = {
     entity: EquipmentLocation;
     save: (x: EquipmentLocation) => void;
+    readOnly?: boolean;
 };
 
-const EquipmentLocationEditor: React.FC<Props> = ({ entity, save }: Props) => {
+const EquipmentLocationEditor: React.FC<Props> = ({ entity, save, readOnly = false }: Props) => {
     return (
         <>
             <Form.Group controlId="formName">
@@ -18,6 +19,7 @@ const EquipmentLocationEditor: React.FC<Props> = ({ entity, save }: Props) => {
                     required
                     type="text"
                     defaultValue={entity?.name}
+                    readOnly={readOnly}
                     onChange={(e) => save({ ...entity, name: e.target.value })}
                 />
             </Form.Group>
@@ -27,6 +29,7 @@ const EquipmentLocationEditor: React.FC<Props> = ({ entity, save }: Props) => {
                     type="number"
                     min="0"
                     value={entity.sortIndex}
+                    readOnly={readOnly}
                     onChange={(e) =>
                         save({
                             ...entity,

--- a/src/components/settings/EquipmentPublicCategoryEditor.tsx
+++ b/src/components/settings/EquipmentPublicCategoryEditor.tsx
@@ -7,9 +7,10 @@ import { FormNumberFieldWithoutScroll } from '../utils/FormNumberFieldWithoutScr
 type Props = {
     entity: EquipmentPublicCategory;
     save: (x: EquipmentPublicCategory) => void;
+    readOnly?: boolean;
 };
 
-const EquipmentPublicCategoryEditor: React.FC<Props> = ({ entity, save }: Props) => {
+const EquipmentPublicCategoryEditor: React.FC<Props> = ({ entity, save, readOnly = false }: Props) => {
     return (
         <>
             <Form.Group controlId="formName">
@@ -17,6 +18,7 @@ const EquipmentPublicCategoryEditor: React.FC<Props> = ({ entity, save }: Props)
                 <Form.Control
                     type="text"
                     defaultValue={entity?.name}
+                    readOnly={readOnly}
                     onChange={(e) => save({ ...entity, name: e.target.value })}
                 />
             </Form.Group>
@@ -25,6 +27,7 @@ const EquipmentPublicCategoryEditor: React.FC<Props> = ({ entity, save }: Props)
                 <Form.Control
                     as="textarea"
                     rows={3}
+                    readOnly={readOnly}
                     onChange={(e) => save({ ...entity, description: e.target.value })}
                     defaultValue={entity.description}
                 />
@@ -35,6 +38,7 @@ const EquipmentPublicCategoryEditor: React.FC<Props> = ({ entity, save }: Props)
                     type="number"
                     min="0"
                     value={entity.sortIndex}
+                    readOnly={readOnly}
                     onChange={(e) =>
                         save({
                             ...entity,

--- a/src/components/settings/EquipmentTagEditor.tsx
+++ b/src/components/settings/EquipmentTagEditor.tsx
@@ -5,10 +5,11 @@ import EquipmentTagDisplay from '../utils/EquipmentTagDisplay';
 
 type Props = {
     entity: EquipmentTag;
+    readOnly?: boolean;
     save: (x: EquipmentTag) => void;
 };
 
-const EquipmentTagEditor: React.FC<Props> = ({ entity, save }: Props) => {
+const EquipmentTagEditor: React.FC<Props> = ({ entity, save, readOnly = false }: Props) => {
     return (
         <>
             <Form.Group controlId="formName">
@@ -16,6 +17,7 @@ const EquipmentTagEditor: React.FC<Props> = ({ entity, save }: Props) => {
                 <Form.Control
                     type="text"
                     defaultValue={entity?.name}
+                    readOnly={readOnly}
                     onChange={(e) => save({ ...entity, name: e.target.value })}
                 />
             </Form.Group>
@@ -24,6 +26,7 @@ const EquipmentTagEditor: React.FC<Props> = ({ entity, save }: Props) => {
                     type="checkbox"
                     label="Visa i publika prislistan"
                     defaultChecked={entity?.isPublic ?? false}
+                    disabled={readOnly}
                     onChange={(e) => save({ ...entity, isPublic: e.target.checked })}
                 />
             </Form.Group>
@@ -33,6 +36,7 @@ const EquipmentTagEditor: React.FC<Props> = ({ entity, save }: Props) => {
                     type="text"
                     placeholder="#FF0000"
                     defaultValue={entity?.color}
+                    readOnly={readOnly}
                     onChange={(e) => save({ ...entity, color: e.target.value })}
                 />
             </Form.Group>

--- a/src/components/settings/GeneralSettingsEditor.tsx
+++ b/src/components/settings/GeneralSettingsEditor.tsx
@@ -15,7 +15,11 @@ import { TableConfiguration, TableDisplay } from '../TableDisplay';
 import ConfirmModal from '../utils/ConfirmModal';
 import SettingsModal from '../utils/setting/SettingsModal';
 
-const GeneralSettingsEditor: React.FC = () => {
+type Props = {
+    readonly?: boolean;
+};
+
+const GeneralSettingsEditor: React.FC<Props> = ({ readonly = false }) => {
     const { data: settings, error, isValidating, mutate } = useSwr('/api/setting', settingsFetcher);
 
     const [settingToEdit, setSettingToEdit] = useState<Setting | null>(null);
@@ -116,10 +120,16 @@ const GeneralSettingsEditor: React.FC = () => {
 
     const SettingEntryActionsDisplayFn = (entry: Setting) => (
         <>
-            <Button variant="secondary" size="sm" onClick={() => setSettingToEdit(entry)} className="mr-2">
+            <Button
+                variant="secondary"
+                size="sm"
+                onClick={() => setSettingToEdit(entry)}
+                className="mr-2"
+                disabled={readonly}
+            >
                 Redigera
             </Button>
-            <Button variant="danger" size="sm" onClick={() => setSettingToDelete(entry)}>
+            <Button variant="danger" size="sm" onClick={() => setSettingToDelete(entry)} disabled={readonly}>
                 Ta bort
             </Button>
         </>
@@ -181,6 +191,7 @@ const GeneralSettingsEditor: React.FC = () => {
                     onClick={() => {
                         setSettingToAdd({ note: '', value: '' });
                     }}
+                    disabled={readonly}
                 >
                     <FontAwesomeIcon icon={faAdd} className="mr-1" /> Lägg till inställning
                 </Button>

--- a/src/lib/sessionContext.ts
+++ b/src/lib/sessionContext.ts
@@ -5,7 +5,7 @@ import { getAndVerifyApiKey, getAndVerifyUser } from './authenticate';
 import { withApiSession } from './session';
 import { IncomingMessage } from 'http';
 import { Role } from '../models/enums/Role';
-import { hasSufficientAccess } from './useUser';
+import { hasSufficientAccess } from './utils';
 
 export interface SessionContext {
     currentUser: CurrentUserInfo;

--- a/src/lib/useUser.ts
+++ b/src/lib/useUser.ts
@@ -6,7 +6,7 @@ import { getAndVerifyUser } from './authenticate';
 import { IncomingMessage } from 'http';
 import { fetchSettings } from './db-access/setting';
 import { KeyValue } from '../models/interfaces/KeyValue';
-import { toKeyValue } from './utils';
+import { hasSufficientAccess, toKeyValue } from './utils';
 
 // This function returns the current user. Depending on if the user is logged in or not
 // and the user's privileges in relation to the specified required role, a redirect will
@@ -68,25 +68,6 @@ const useUserWithDefaultAccessAndWithSettings = (requiredRole: Role = Role.READO
     return useUser('/login', '/no-access', undefined, true, requiredRole);
 };
 
-const hasSufficientAccess = (role: Role | null | undefined, requiredRole: Role | null) => {
-    switch (requiredRole) {
-        case Role.ADMIN:
-            return role === Role.ADMIN;
-
-        case Role.USER:
-            return role === Role.USER || role === Role.ADMIN;
-
-        case Role.READONLY:
-            return role === Role.READONLY || role === Role.USER || role === Role.ADMIN;
-
-        case Role.CASH_PAYMENT_MANAGER:
-            return role === Role.CASH_PAYMENT_MANAGER || role === Role.USER || role === Role.ADMIN;
-
-        case null:
-            return true;
-    }
-};
-
 const getGlobalSettings = async (isLoggedIn = false) => {
     const settings = (await fetchSettings()).map(toKeyValue);
     const publicSettings = [
@@ -139,4 +120,4 @@ const getGlobalSettings = async (isLoggedIn = false) => {
     return isLoggedIn ? globalSettings : globalSettings.filter((s) => publicSettings.includes(s.key));
 };
 
-export { useUser, useUserWithDefaultAccessAndWithSettings, hasSufficientAccess, getGlobalSettings };
+export { useUser, useUserWithDefaultAccessAndWithSettings, getGlobalSettings };

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -448,3 +448,22 @@ export const getOperationalYear = (date?: Date) => {
 
     return formatOperationalYear(date.getFullYear());
 };
+
+export const hasSufficientAccess = (role: Role | null | undefined, requiredRole: Role | null) => {
+    switch (requiredRole) {
+        case Role.ADMIN:
+            return role === Role.ADMIN;
+
+        case Role.USER:
+            return role === Role.USER || role === Role.ADMIN;
+
+        case Role.READONLY:
+            return role === Role.READONLY || role === Role.USER || role === Role.ADMIN;
+
+        case Role.CASH_PAYMENT_MANAGER:
+            return role === Role.CASH_PAYMENT_MANAGER || role === Role.USER || role === Role.ADMIN;
+
+        case null:
+            return true;
+    }
+};

--- a/src/pages/settings.tsx
+++ b/src/pages/settings.tsx
@@ -20,7 +20,7 @@ import { KeyValue } from '../models/interfaces/KeyValue';
 import { Role } from '../models/enums/Role';
 
 // eslint-disable-next-line react-hooks/rules-of-hooks
-export const getServerSideProps = useUserWithDefaultAccessAndWithSettings(Role.ADMIN);
+export const getServerSideProps = useUserWithDefaultAccessAndWithSettings();
 type Props = { user: CurrentUserInfo; globalSettings: KeyValue[] };
 const pageTitle = 'Inställningar';
 const breadcrumbs = [{ link: 'settings', displayName: pageTitle }];
@@ -28,6 +28,8 @@ const breadcrumbs = [{ link: 'settings', displayName: pageTitle }];
 // Page
 //
 const SettingsPage: React.FC<Props> = ({ user: currentUser, globalSettings }: Props) => {
+    const readonly = currentUser.role !== Role.ADMIN;
+
     return (
         <Layout title={pageTitle} fixedWidth={true} currentUser={currentUser} globalSettings={globalSettings}>
             <Header title={pageTitle} breadcrumbs={breadcrumbs}></Header>
@@ -57,7 +59,10 @@ const SettingsPage: React.FC<Props> = ({ user: currentUser, globalSettings }: Pr
                             apiUrl={'/api/customers'}
                             entityName={'customer'}
                             entityDisplayName={'Kund'}
-                            getEditComponent={(entity, save) => <CustomerEditor entity={entity} save={save} />}
+                            getEditComponent={(entity, save, readOnly) => (
+                                <CustomerEditor entity={entity} save={save} readOnly={readOnly} />
+                            )}
+                            readonly={readonly}
                         />
                     </Tab.Pane>
                     <Tab.Pane eventKey="equipmentTags">
@@ -66,7 +71,10 @@ const SettingsPage: React.FC<Props> = ({ user: currentUser, globalSettings }: Pr
                             apiUrl={'/api/equipmentTags'}
                             entityName={'equipmentTag'}
                             entityDisplayName={'Tagg'}
-                            getEditComponent={(entity, save) => <EquipmentTagEditor entity={entity} save={save} />}
+                            getEditComponent={(entity, save, readOnly) => (
+                                <EquipmentTagEditor entity={entity} save={save} readOnly={readOnly} />
+                            )}
+                            readonly={readonly}
                         />
                     </Tab.Pane>
                     <Tab.Pane eventKey="equipmentLocations">
@@ -75,8 +83,11 @@ const SettingsPage: React.FC<Props> = ({ user: currentUser, globalSettings }: Pr
                             apiUrl={'/api/equipmentLocations'}
                             entityName={'equipmentLocation'}
                             entityDisplayName={'Plats'}
-                            getEditComponent={(entity, save) => <EquipmentLocationEditor entity={entity} save={save} />}
+                            getEditComponent={(entity, save, readOnly) => (
+                                <EquipmentLocationEditor entity={entity} save={save} readOnly={readOnly} />
+                            )}
                             sortBySortIndex={true}
+                            readonly={readonly}
                         />
                     </Tab.Pane>
                     <Tab.Pane eventKey="equipmentPublicCategories">
@@ -85,14 +96,15 @@ const SettingsPage: React.FC<Props> = ({ user: currentUser, globalSettings }: Pr
                             apiUrl={'/api/equipmentPublicCategories'}
                             entityName={'equipmentPublicCategory'}
                             entityDisplayName={'Publik Kategori'}
-                            getEditComponent={(entity, save) => (
-                                <EquipmentPublicCategoryEditor entity={entity} save={save} />
+                            getEditComponent={(entity, save, readOnly) => (
+                                <EquipmentPublicCategoryEditor entity={entity} save={save} readOnly={readOnly} />
                             )}
+                            readonly={readonly}
                             sortBySortIndex={true}
                         />
                     </Tab.Pane>
                     <Tab.Pane eventKey="generalSettings">
-                        <GeneralSettingsEditor />
+                        <GeneralSettingsEditor readonly={readonly} />
                     </Tab.Pane>
                 </Tab.Content>
             </Tab.Container>


### PR DESCRIPTION
Allow all users to see all settings (but only admins to edit them). In the new readonly-mode the 'redigera' button becomes a 'Visa detaljer' button and all edit fields and save/add buttons are disabled.

Trello card: https://trello.com/c/WUCpi1Qk/418-justera-synlighet-och-skrivr%C3%A4ttigheter-p%C3%A5-kundlistan