### PR TITLE
Bugfix: Show all past bookings on equipment

### DIFF
--- a/src/components/equipment/EquipmentBookings.tsx
+++ b/src/components/equipment/EquipmentBookings.tsx
@@ -39,16 +39,14 @@ const EquipmentBookings: React.FC<Props> = ({ equipment }: Props) => {
             x.equipmentInDatetime.getTime() > Date.now() &&
             !bookingHasNonReturnedListWithEquipment(x),
     );
-    const pastBookings = bookingViewModels
-        .filter(
-            (x) =>
-                x.equipmentOutDatetime &&
-                x.equipmentInDatetime &&
-                x.equipmentOutDatetime.getTime() < Date.now() &&
-                x.equipmentInDatetime.getTime() < Date.now() &&
-                !bookingHasNonReturnedListWithEquipment(x),
-        )
-        .slice(0, 10);
+    const pastBookings = bookingViewModels.filter(
+        (x) =>
+            x.equipmentOutDatetime &&
+            x.equipmentInDatetime &&
+            x.equipmentOutDatetime.getTime() < Date.now() &&
+            x.equipmentInDatetime.getTime() < Date.now() &&
+            !bookingHasNonReturnedListWithEquipment(x),
+    );
 
     if (!equipment || !bookings) {
         return <Skeleton height={120}></Skeleton>;
@@ -67,7 +65,7 @@ const EquipmentBookings: React.FC<Props> = ({ equipment }: Props) => {
                 tableSettingsOverride={{ noResultsLabel: 'Inga kommande bokningar med ' + equipment.name }}
             />
             <TinyBookingTable
-                title={'Senaste 10 bokningarna som använt ' + equipment.name}
+                title={'Tidigare bokningar'}
                 bookings={pastBookings}
                 tableSettingsOverride={{
                     defaultSortAscending: false,


### PR DESCRIPTION
The "top 10" filter on past bookings did not work correctly since the list isn't sorted. Since it might be interesting to see more than 10 bookings (and we load them from the server regardless) I just show all of them.

Trello card: https://trello.com/c/T1Gkqxbz/415-senaste-10-bokningarna-som-anv%C3%A4nt-utrustning-verkar-inte-uppdatera-efter-%C3%A5rsskiftet-se-tex-tri-led