### PR TITLE
Bugfix: Rename DoubleClickToEdit component and fix value tracking

### DIFF
--- a/src/components/admin/AdminBookingList.tsx
+++ b/src/components/admin/AdminBookingList.tsx
@@ -19,7 +19,7 @@ import { BookingViewModel } from '../../models/interfaces';
 import { TableConfiguration, TableDisplay } from '../TableDisplay';
 import BookingTypeTag from '../utils/BookingTypeTag';
 import DoneIcon from '../utils/DoneIcon';
-import { DoubleClickToEdit } from '../utils/DoubleClickToEdit';
+import { ClickToEdit } from '../utils/DoubleClickToEdit';
 import FixedPriceStatusTag from '../utils/FixedPriceStatusTag';
 import TableStyleLink from '../utils/TableStyleLink';
 import { getBookingDateHeadingValue } from '../../lib/datetimeUtils';
@@ -75,7 +75,7 @@ const AdminBookingList: React.FC<Props> = ({
 
     const bookingReferenceDisplayFn = (booking: BookingViewModel) => (
         <>
-            <DoubleClickToEdit
+            <ClickToEdit
                 readonly={!allowEditInvoiceNumber}
                 onUpdate={(newInvoiceNumber: string) => {
                     if (!updateInvoiceNumber) {
@@ -86,7 +86,7 @@ const AdminBookingList: React.FC<Props> = ({
                 value={booking.invoiceNumber}
             >
                 {replaceEmptyStringWithNull(booking.invoiceNumber) ?? <span className="text-muted">XXXXXXX</span>}
-            </DoubleClickToEdit>
+            </ClickToEdit>
         </>
     );
 

--- a/src/components/bookings/equipmentLists/EquipmentListHeader.tsx
+++ b/src/components/bookings/equipmentLists/EquipmentListHeader.tsx
@@ -17,7 +17,7 @@ import {
 } from '@fortawesome/free-solid-svg-icons';
 import { EquipmentList, EquipmentListEntry, EquipmentListHeading } from '../../../models/interfaces/EquipmentList';
 import { toIntOrUndefined, getRentalStatusName } from '../../../lib/utils';
-import { DoubleClickToEdit } from '../../utils/DoubleClickToEdit';
+import { ClickToEdit } from '../../utils/DoubleClickToEdit';
 import { addVAT, formatCurrency, getEquipmentListPrice } from '../../../lib/pricingUtils';
 import { PricePlan } from '../../../models/enums/PricePlan';
 import {
@@ -114,7 +114,7 @@ const EquipmentListHeader: React.FC<Props> = ({
         <>
             <div className="d-flex">
                 <div className="flex-grow-1 mr-4" style={{ fontSize: '1.6em' }}>
-                    <DoubleClickToEdit
+                    <ClickToEdit
                         value={list.name}
                         onUpdate={(newValue: string) =>
                             saveList({
@@ -125,7 +125,7 @@ const EquipmentListHeader: React.FC<Props> = ({
                         readonly={readonly}
                     >
                         {list.name}
-                    </DoubleClickToEdit>
+                    </ClickToEdit>
                 </div>
                 <div className="d-flex">
                     <Button className="mr-2" variant="" onClick={() => toggleListContent()}>
@@ -358,7 +358,7 @@ const EquipmentListHeader: React.FC<Props> = ({
                     <div className="d-flex">
                         <div className="flex-grow-1">
                             <div className="mb-3" style={{ fontSize: '1.2em' }}>
-                                <DoubleClickToEdit
+                                <ClickToEdit
                                     value={list.numberOfDays?.toString()}
                                     inputType="number"
                                     onUpdate={(newValue) =>
@@ -371,7 +371,7 @@ const EquipmentListHeader: React.FC<Props> = ({
                                     className="mb-3 d-block"
                                 >
                                     {list.numberOfDays} {list.numberOfDays != 1 ? 'dagar' : 'dag'}
-                                </DoubleClickToEdit>
+                                </ClickToEdit>
                             </div>
                         </div>
                         {readonly ? null : (

--- a/src/components/bookings/equipmentLists/EquipmentListTable.tsx
+++ b/src/components/bookings/equipmentLists/EquipmentListTable.tsx
@@ -21,7 +21,7 @@ import { EquipmentList, EquipmentListEntry, EquipmentListHeading } from '../../.
 import { TableConfiguration, TableDisplay } from '../../TableDisplay';
 import { toIntOrUndefined, reduceSumFn, getResponseContentOrError } from '../../../lib/utils';
 import EquipmentSearch, { ResultType } from '../../EquipmentSearch';
-import { DoubleClickToEdit, DoubleClickToEditDropdown } from '../../utils/DoubleClickToEdit';
+import { ClickToEdit, ClickToEditDropdown } from '../../utils/DoubleClickToEdit';
 import {
     addVAT,
     addVATToPrice,
@@ -123,7 +123,7 @@ const EquipmentListTable: React.FC<Props> = ({
             return (
                 <>
                     <div className="mb-0">
-                        <DoubleClickToEdit
+                        <ClickToEdit
                             value={heading.name}
                             onUpdate={(newValue) =>
                                 saveListHeading({
@@ -138,10 +138,10 @@ const EquipmentListTable: React.FC<Props> = ({
                             <span className="text-muted ml-2">
                                 ({heading.listEntries.length} {heading.listEntries.length === 1 ? 'del' : 'delar'})
                             </span>
-                        </DoubleClickToEdit>
+                        </ClickToEdit>
                     </div>
                     <div className="mb-0 text-muted">
-                        <DoubleClickToEdit
+                        <ClickToEdit
                             value={heading.description}
                             onUpdate={(newValue) =>
                                 saveListHeading({
@@ -159,7 +159,7 @@ const EquipmentListTable: React.FC<Props> = ({
                                     {readonly ? null : 'Dubbelklicka för att lägga till en beskrivning'}
                                 </span>
                             )}{' '}
-                        </DoubleClickToEdit>
+                        </ClickToEdit>
                     </div>
                 </>
             );
@@ -170,7 +170,7 @@ const EquipmentListTable: React.FC<Props> = ({
         return (
             <>
                 <div className={'mb-0' + (entry.isHidden ? ' text-muted' : '')}>
-                    <DoubleClickToEdit
+                    <ClickToEdit
                         value={entry.name}
                         onUpdate={(newValue) =>
                             saveListEntry({ ...entry, name: newValue && newValue.length > 0 ? newValue : entry.name })
@@ -219,10 +219,10 @@ const EquipmentListTable: React.FC<Props> = ({
                                 <FontAwesomeIcon icon={faDollarSign} className="ml-1" title="" />
                             </OverlayTrigger>
                         ) : null}
-                    </DoubleClickToEdit>
+                    </ClickToEdit>
                 </div>
                 <div className="mb-0">
-                    <DoubleClickToEdit
+                    <ClickToEdit
                         value={entry.description}
                         onUpdate={(newValue) => saveListEntry({ ...entry, description: newValue })}
                         size="sm"
@@ -235,7 +235,7 @@ const EquipmentListTable: React.FC<Props> = ({
                                 {readonly ? null : 'Dubbelklicka för att lägga till en beskrivning'}
                             </span>
                         )}
-                    </DoubleClickToEdit>
+                    </ClickToEdit>
                 </div>
 
                 <div className="mb-0 text-muted d-md-none">{EquipmentListEntryNumberOfHoursDisplayFn(viewModel)}</div>
@@ -259,7 +259,7 @@ const EquipmentListTable: React.FC<Props> = ({
         }
 
         return (
-            <DoubleClickToEdit
+            <ClickToEdit
                 value={entry.numberOfUnits?.toString()}
                 onUpdate={(newValue) =>
                     saveListEntry({ ...entry, numberOfUnits: toIntOrUndefined(newValue, true) ?? 0 })
@@ -268,7 +268,7 @@ const EquipmentListTable: React.FC<Props> = ({
                 readonly={readonly}
             >
                 <span className={valueIsRelevant ? '' : 'text-muted'}>{entry.numberOfUnits} st</span>
-            </DoubleClickToEdit>
+            </ClickToEdit>
         );
     };
 
@@ -285,7 +285,7 @@ const EquipmentListTable: React.FC<Props> = ({
         }
 
         return (
-            <DoubleClickToEdit
+            <ClickToEdit
                 value={entry.numberOfHours.toString()}
                 onUpdate={(newValue) =>
                     saveListEntry({ ...entry, numberOfHours: toIntOrUndefined(newValue, true) ?? 0 })
@@ -294,7 +294,7 @@ const EquipmentListTable: React.FC<Props> = ({
                 readonly={readonly}
             >
                 <span className={valueIsRelevant ? '' : 'text-muted'}>{entry.numberOfHours} h</span>
-            </DoubleClickToEdit>
+            </ClickToEdit>
         );
     };
 
@@ -319,7 +319,7 @@ const EquipmentListTable: React.FC<Props> = ({
         };
         return entry.equipment && entry.equipment.prices.length ? (
             <span className={showPricesAsMuted ? 'text-muted' : ''}>
-                <DoubleClickToEditDropdown<EquipmentPrice>
+                <ClickToEditDropdown<EquipmentPrice>
                     options={
                         entry.equipmentPrice
                             ? entry.equipment.prices
@@ -344,7 +344,7 @@ const EquipmentListTable: React.FC<Props> = ({
                     {entry.equipmentPrice && entry.equipment.prices.length > 1 ? (
                         <p className="text-muted mb-0">{entry.equipmentPrice.name}</p>
                     ) : null}
-                </DoubleClickToEditDropdown>
+                </ClickToEditDropdown>
             </span>
         ) : (
             <span className={showPricesAsMuted ? 'text-muted' : ''}>{formatPrice(addVATToPrice(entry))}</span>

--- a/src/components/bookings/timeEstimate/TimeEstimateList.tsx
+++ b/src/components/bookings/timeEstimate/TimeEstimateList.tsx
@@ -8,7 +8,7 @@ import { getResponseContentOrError, toIntOrUndefined, updateItemsInArrayById } f
 import { toTimeEstimate } from '../../../lib/mappers/timeEstimate';
 import { TimeEstimate } from '../../../models/interfaces/TimeEstimate';
 import { useNotifications } from '../../../lib/useNotifications';
-import { DoubleClickToEdit } from '../../utils/DoubleClickToEdit';
+import { ClickToEdit } from '../../utils/DoubleClickToEdit';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import {
     faAngleDown,
@@ -149,7 +149,7 @@ const TimeEstimateList: React.FC<Props> = ({ bookingId, readonly, defaultLaborHo
     };
 
     const TimeEstimateNameDisplayFn = (timeEstimate: TimeEstimate) => (
-        <DoubleClickToEdit
+        <ClickToEdit
             value={timeEstimate.name}
             onUpdate={(newValue) =>
                 updateTimeEstimates({
@@ -165,11 +165,11 @@ const TimeEstimateList: React.FC<Props> = ({ bookingId, readonly, defaultLaborHo
             ) : (
                 <span className="text-muted font-italic">Dubbelklicka för att lägga till en beskrivning</span>
             )}
-        </DoubleClickToEdit>
+        </ClickToEdit>
     );
 
     const TimeEstimateNumberOfHoursDisplayFn = (timeEstimate: TimeEstimate) => (
-        <DoubleClickToEdit
+        <ClickToEdit
             value={timeEstimate.numberOfHours?.toString()}
             onUpdate={(newValue) =>
                 updateTimeEstimates({
@@ -185,7 +185,7 @@ const TimeEstimateList: React.FC<Props> = ({ bookingId, readonly, defaultLaborHo
             ) : (
                 timeEstimate.numberOfHours + ' h'
             )}
-        </DoubleClickToEdit>
+        </ClickToEdit>
     );
 
     const TimeEstimateTotalPriceDisplayFn = (entry: TimeEstimate) => {

--- a/src/components/bookings/timeReport/TimeReportList.tsx
+++ b/src/components/bookings/timeReport/TimeReportList.tsx
@@ -24,7 +24,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { toTimeReport } from '../../../lib/mappers/timeReport';
 import { addVAT, formatCurrency, getTimeReportPrice, getTotalTimeReportsPrice } from '../../../lib/pricingUtils';
 import { useNotifications } from '../../../lib/useNotifications';
-import { DoubleClickToEdit } from '../../utils/DoubleClickToEdit';
+import { ClickToEdit } from '../../utils/DoubleClickToEdit';
 import {
     getNextSortIndex,
     isFirst,
@@ -164,7 +164,7 @@ const TimeReportList: React.FC<Props> = ({ bookingId, currentUser, readonly, def
 
     const TimeReportSpecificationDisplayFn = (timeReport: TimeReport) => (
         <>
-            <DoubleClickToEdit
+            <ClickToEdit
                 value={timeReport.name}
                 onUpdate={(newValue) =>
                     updateTimeReports({
@@ -180,7 +180,7 @@ const TimeReportList: React.FC<Props> = ({ bookingId, currentUser, readonly, def
                 ) : (
                     <span className="text-muted font-italic">Dubbelklicka för att lägga till en beskrivning</span>
                 )}
-            </DoubleClickToEdit>
+            </ClickToEdit>
             {readonly ? (
                 <p className="text-muted">
                     {formatDatetime(timeReport.startDatetime)} - {formatDatetime(timeReport.endDatetime)}
@@ -194,7 +194,7 @@ const TimeReportList: React.FC<Props> = ({ bookingId, currentUser, readonly, def
     );
 
     const TimeReportBillableWorkingHoursDisplayFn = (timeReport: TimeReport) => (
-        <DoubleClickToEdit
+        <ClickToEdit
             value={timeReport.billableWorkingHours?.toString()}
             onUpdate={(newValue) =>
                 updateTimeReports({
@@ -206,7 +206,7 @@ const TimeReportList: React.FC<Props> = ({ bookingId, currentUser, readonly, def
             readonly={readonly}
         >
             <TimeReportHourDisplay timeReport={timeReport} />
-        </DoubleClickToEdit>
+        </ClickToEdit>
     );
 
     const TimeReportUserIdDisplayFn = (timeReport: TimeReport) => (

--- a/src/components/utils/DoubleClickToEdit.tsx
+++ b/src/components/utils/DoubleClickToEdit.tsx
@@ -1,10 +1,9 @@
 import React, { ReactNode, useEffect, useState } from 'react';
 import { Form } from 'react-bootstrap';
-import { formatDatetime, formatDatetimeForForm, toDatetimeOrUndefined } from '../../lib/datetimeUtils';
 
-const doubleClickToEditHelpText = 'Dubbelklicka för att redigera';
+const doubleClickToEditHelpText = 'Klicka för att redigera';
 
-type DoubleClickToEditProps = {
+type ClickToEditProps = {
     children?: ReactNode;
     value?: string;
     size?: 'sm' | 'lg' | undefined;
@@ -16,7 +15,7 @@ type DoubleClickToEditProps = {
     max?: string;
 };
 
-export const DoubleClickToEdit: React.FC<DoubleClickToEditProps> = ({
+export const ClickToEdit: React.FC<ClickToEditProps> = ({
     value,
     onUpdate,
     size,
@@ -26,7 +25,7 @@ export const DoubleClickToEdit: React.FC<DoubleClickToEditProps> = ({
     className,
     min,
     max,
-}: DoubleClickToEditProps) => {
+}: ClickToEditProps) => {
     const [trackedValue, setTrackedValue] = useState(value ?? '');
     const [isEditing, setIsEditing] = useState(false);
 
@@ -37,10 +36,10 @@ export const DoubleClickToEdit: React.FC<DoubleClickToEditProps> = ({
         }
     };
 
-    const startEditing= () => {
+    const startEditing = () => {
         setTrackedValue(value ?? '');
-        setIsEditing(true)
-    }
+        setIsEditing(true);
+    };
 
     if (readonly) {
         return <span>{children}</span>;
@@ -79,7 +78,7 @@ export const DoubleClickToEdit: React.FC<DoubleClickToEditProps> = ({
     );
 };
 
-type DoubleClickToEditDropdownProps<T> = {
+type ClickToEditDropdownProps<T> = {
     children?: ReactNode;
     options: T[];
     optionLabelFn: (option: T) => string;
@@ -91,7 +90,7 @@ type DoubleClickToEditDropdownProps<T> = {
     readonly?: boolean;
 };
 
-export const DoubleClickToEditDropdown = <T,>({
+export const ClickToEditDropdown = <T,>({
     value,
     options,
     optionLabelFn,
@@ -101,7 +100,7 @@ export const DoubleClickToEditDropdown = <T,>({
     size,
     children,
     readonly,
-}: DoubleClickToEditDropdownProps<T>): React.ReactElement => {
+}: ClickToEditDropdownProps<T>): React.ReactElement => {
     const [selectedKey, setSelectedKey] = useState(optionKeyFn(value));
     const [isEditing, setIsEditing] = useState(false);
 

--- a/src/components/utils/DoubleClickToEdit.tsx
+++ b/src/components/utils/DoubleClickToEdit.tsx
@@ -37,6 +37,11 @@ export const DoubleClickToEdit: React.FC<DoubleClickToEditProps> = ({
         }
     };
 
+    const startEditing= () => {
+        setTrackedValue(value ?? '');
+        setIsEditing(true)
+    }
+
     if (readonly) {
         return <span>{children}</span>;
     }
@@ -49,7 +54,7 @@ export const DoubleClickToEdit: React.FC<DoubleClickToEditProps> = ({
                 title={doubleClickToEditHelpText}
                 tabIndex={0}
                 onDoubleClick={() => setIsEditing(true)}
-                onFocus={() => setIsEditing(true)}
+                onFocus={() => startEditing()}
             >
                 {children}
             </span>
@@ -71,51 +76,6 @@ export const DoubleClickToEdit: React.FC<DoubleClickToEditProps> = ({
             onFocus={(e: React.FocusEvent<HTMLInputElement>) => e.target.select()}
             autoFocus
         />
-    );
-};
-
-type DoubleClickToEditDatetimeProps = {
-    value?: Date | null;
-    onUpdate: (x: Date | undefined) => void;
-    size?: 'sm' | 'lg' | undefined;
-    readonly?: boolean;
-    className?: string;
-    placeholder?: string;
-    min?: string;
-    max?: string;
-};
-
-export const DoubleClickToEditDatetime: React.FC<DoubleClickToEditDatetimeProps> = ({
-    value,
-    onUpdate,
-    size,
-    readonly,
-    className,
-    placeholder = 'N/A',
-    min,
-    max,
-}: DoubleClickToEditDatetimeProps) => {
-    return (
-        <DoubleClickToEdit
-            inputType="datetime-local"
-            value={value ? formatDatetimeForForm(value) : ''}
-            onUpdate={(newValue) => onUpdate(toDatetimeOrUndefined(newValue))}
-            size={size}
-            readonly={readonly}
-            className={className}
-            min={min}
-            max={max}
-        >
-            <div className="mb-3">
-                {value ? (
-                    formatDatetime(value)
-                ) : (
-                    <span className="text-muted" title="Dubbelklicka för att konfigurera">
-                        {placeholder}
-                    </span>
-                )}
-            </div>
-        </DoubleClickToEdit>
     );
 };
 


### PR DESCRIPTION
* Rename DoubleClickToEdit component to ClickToEdit
* Fix tracking error when value is changed elsewhere after component is rendered

Trello card: https://trello.com/c/lkgc5edt/386-om-man-byter-namn-p%C3%A5-en-tidsrapport-via-avancerad-redigering-och-sedan-f%C3%B6rs%C3%B6ker-byta-namn-genom-att-klicka-p%C3%A5-namnet-och-avbryte