### PR TITLE
Feature: Add analytics API

### DIFF
--- a/src/lib/db-access/booking.ts
+++ b/src/lib/db-access/booking.ts
@@ -45,6 +45,7 @@ export const fetchBookings = async (): Promise<BookingObjectionModel[]> => {
 
     return BookingObjectionModel.query()
         .withGraphFetched('ownerUser')
+        .withGraphFetched('timeEstimates')
         .withGraphFetched('timeReports.user')
         .withGraphFetched('equipmentLists.listEntries.equipment')
         .withGraphFetched('equipmentLists.listHeadings.listEntries.equipment');

--- a/src/pages/api/external/v1/analytics/bookings.ts
+++ b/src/pages/api/external/v1/analytics/bookings.ts
@@ -44,7 +44,6 @@ interface BookingAnalyticsModel {
     pricePlan: number;
     accountKind: number | null;
     location: string;
-    customerName: string;
     language: string;
     fixedPrice?: number | null;
     totalTimeEstimatesPrice: number;
@@ -74,7 +73,6 @@ const mapToAnalytics = (bookings: BookingViewModel[]): BookingAnalyticsModel[] =
         pricePlan: booking.pricePlan,
         accountKind: booking.accountKind,
         location: booking.location,
-        customerName: booking.customerName,
         language: booking.language,
 
         // Pricing

--- a/src/pages/api/external/v1/analytics/bookings.ts
+++ b/src/pages/api/external/v1/analytics/bookings.ts
@@ -54,6 +54,9 @@ interface BookingAnalyticsModel {
     usageEndDatetime: string | undefined;
     equipmentOutDatetime: string | undefined;
     equipmentInDatetime: string | undefined;
+    estimatedHours: number;
+    actualWorkingHours: number;
+    billableWorkingHours: number;
 }
 
 const mapToAnalytics = (bookings: BookingViewModel[]): BookingAnalyticsModel[] =>
@@ -86,6 +89,11 @@ const mapToAnalytics = (bookings: BookingViewModel[]): BookingAnalyticsModel[] =
         usageEndDatetime: formatDatetimeForForm(booking.usageEndDatetime),
         equipmentOutDatetime: formatDatetimeForForm(booking.equipmentOutDatetime),
         equipmentInDatetime: formatDatetimeForForm(booking.equipmentInDatetime),
+
+        // Working hours
+        estimatedHours: booking.timeEstimates?.reduce((sum, entry) => sum + entry.numberOfHours, 0) ?? 0,
+        actualWorkingHours: booking.timeReports?.reduce((sum, entry) => sum + entry.actualWorkingHours, 0) ?? 0,
+        billableWorkingHours: booking.timeReports?.reduce((sum, entry) => sum + entry.billableWorkingHours, 0) ?? 0,
     }));
 
 const mapToCSV = (bookings: BookingAnalyticsModel[]) => {

--- a/src/pages/api/external/v1/analytics/bookings.ts
+++ b/src/pages/api/external/v1/analytics/bookings.ts
@@ -1,0 +1,104 @@
+import { NextApiRequest, NextApiResponse } from 'next';
+import { respondWithCustomErrorMessage, respondWithInvalidMethodResponse } from '../../../../../lib/apiResponses';
+import { fetchBookings } from '../../../../../lib/db-access';
+import { withApiKeyContext } from '../../../../../lib/sessionContext';
+import {
+    getEquipmentListPrice,
+    getTotalTimeEstimatesPrice,
+    getTotalTimeReportsPrice,
+} from '../../../../../lib/pricingUtils';
+import { BookingViewModel } from '../../../../../models/interfaces';
+import { toBooking } from '../../../../../lib/mappers/booking';
+import currency from 'currency.js';
+import { formatDatetimeForForm, toBookingViewModel } from '../../../../../lib/datetimeUtils';
+
+const handler = withApiKeyContext(async (req: NextApiRequest, res: NextApiResponse): Promise<void> => {
+    switch (req.method) {
+        case 'GET':
+            await fetchBookings()
+                .then((x) => x.map(toBooking))
+                .then((x) => x.map(toBookingViewModel))
+                .then((x) => mapToAnalytics(x))
+                .then((x) => mapToCSV(x))
+                .then((result) => res.status(200).setHeader('Content-Type', 'text/csv').send(result))
+                .catch((error) => respondWithCustomErrorMessage(res, error.message));
+            break;
+
+        default:
+            respondWithInvalidMethodResponse(res);
+    }
+    return;
+});
+
+interface BookingAnalyticsModel {
+    id: number;
+    name: string;
+    created?: string;
+    ownerUserName?: string;
+    ownerUserId?: number;
+    bookingType: number;
+    status: number;
+    paymentStatus: number;
+    invoiceHogiaId: number | null;
+    salaryStatus: number;
+    pricePlan: number;
+    accountKind: number | null;
+    location: string;
+    customerName: string;
+    language: string;
+    fixedPrice?: number | null;
+    totalTimeEstimatesPrice: number;
+    totalTimeReportsPrice: number;
+    totalEquipmentPrice: number;
+    usageStartDatetime: string | undefined;
+    usageEndDatetime: string | undefined;
+    equipmentOutDatetime: string | undefined;
+    equipmentInDatetime: string | undefined;
+}
+
+const mapToAnalytics = (bookings: BookingViewModel[]): BookingAnalyticsModel[] =>
+    bookings.map((booking) => ({
+        id: booking.id,
+        name: booking.name,
+        created: formatDatetimeForForm(booking.created),
+        ownerUserName: booking.ownerUser?.name,
+        ownerUserId: booking.ownerUserId,
+        bookingType: booking.bookingType,
+        status: booking.status,
+        salaryStatus: booking.salaryStatus,
+        paymentStatus: booking.paymentStatus,
+        invoiceHogiaId: booking.invoiceHogiaId,
+        pricePlan: booking.pricePlan,
+        accountKind: booking.accountKind,
+        location: booking.location,
+        customerName: booking.customerName,
+        language: booking.language,
+
+        // Pricing
+        fixedPrice: booking.fixedPrice,
+        totalTimeEstimatesPrice: getTotalTimeEstimatesPrice(booking.timeEstimates).value,
+        totalTimeReportsPrice: getTotalTimeReportsPrice(booking.timeReports).value,
+        totalEquipmentPrice:
+            booking.equipmentLists?.reduce((sum, l) => sum.add(getEquipmentListPrice(l)), currency(0)).value ?? 0,
+
+        // Dates
+        usageStartDatetime: formatDatetimeForForm(booking.usageStartDatetime),
+        usageEndDatetime: formatDatetimeForForm(booking.usageEndDatetime),
+        equipmentOutDatetime: formatDatetimeForForm(booking.equipmentOutDatetime),
+        equipmentInDatetime: formatDatetimeForForm(booking.equipmentInDatetime),
+    }));
+
+const mapToCSV = (bookings: BookingAnalyticsModel[]) => {
+    const headings = Object.keys(bookings[0]);
+    const headerRow = headings.join(',');
+
+    const bookingRows = bookings.map((booking) =>
+        headings
+            .map((fieldName) => JSON.stringify((booking as unknown as { [name: string]: string })[fieldName]))
+            .join(','),
+    );
+
+    return [headerRow, ...bookingRows].join('\r\n');
+};
+
+export default handler;


### PR DESCRIPTION
Add an endpoint to fetch basic analytics in csv format for analysis elsewhere. It uses the public API support introduced in PR #25, i.e. you need an API key to access the endpoint.

This PR provides a minimal set of information on a booking level to enable a proof-of-concept analytics page. For each booking the following data is provided:
* Basic information such as name, type, responsible user, created date location, and language
* All booking-level statuses (booking, payment, salary)
* Customer information (name and hogia id)
* Pricing metadata (price plan and account kind)
* Pricing (equipment total, time estimate total and time report total)
* Dates (usage start/end and equipment in/out)
* Working hours information (estimated, actual and billable)

See example response below:
![image](https://github.com/rneventteknik/backstage2/assets/3681132/c00e49dd-a125-45ad-b7be-3c9a7db6b331)


The endpoint is available at `/api/external/v1/analytics/bookings` and takes no parameters, i.e. it always returns the full set of bookings. If this turns out to be a performance problem we can add filters in the future, for example including only bookings modified within a certain time period.

Trello card: https://trello.com/c/vX4mI3RN/440-implementera-rn-analytics