### PR TITLE
Bugfix: Fix remove connected equipment

### DIFF
--- a/src/components/bookings/equipmentLists/CopyEquipmentListEntriesModal.tsx
+++ b/src/components/bookings/equipmentLists/CopyEquipmentListEntriesModal.tsx
@@ -186,10 +186,10 @@ const CopyEquipmentListEntriesModal: React.FC<Props> = ({ show, onHide, onImport
         };
     };
 
-    const getEquipmentName = (equipment: Equipment | undefined) =>
+    const getEquipmentName = (equipment: Equipment | undefined | null) =>
         language === Language.SV ? equipment?.name : equipment?.nameEN;
 
-    const getEquipmentDescription = (equipment: Equipment | undefined) =>
+    const getEquipmentDescription = (equipment: Equipment | undefined | null) =>
         language === Language.SV ? equipment?.description : equipment?.descriptionEN;
 
     const isDisabled = (entry: EquipmentListEntry) => entry.equipment?.isArchived;

--- a/src/components/bookings/equipmentLists/EditEquipmentListEntryModal.tsx
+++ b/src/components/bookings/equipmentLists/EditEquipmentListEntryModal.tsx
@@ -285,9 +285,9 @@ const EditEquipmentListEntryModal: React.FC<Props> = ({
                                     onClick={() =>
                                         setEquipmentListEntryToEditViewModel({
                                             ...equipmentListEntryToEditViewModel,
-                                            equipment: undefined,
-                                            equipmentId: undefined,
-                                            equipmentPrice: undefined,
+                                            equipment: null,
+                                            equipmentId: null,
+                                            equipmentPrice: null,
                                         })
                                     }
                                 >

--- a/src/lib/mappers/booking.ts
+++ b/src/lib/mappers/booking.ts
@@ -160,7 +160,7 @@ export const toEquipmentListEntryObjectionModel = (
         updated: undefined,
         id: clientModel.id,
         equipment: undefined,
-        equipmentId: clientModel.equipment?.id,
+        equipmentId: clientModel.equipment?.id ?? null,
         equipmentPrice: undefined,
         equipmentPriceId: clientModel.equipmentPrice?.id ?? null,
         pricePerHour: clientModel.pricePerHour?.value,

--- a/src/models/interfaces/EquipmentList.ts
+++ b/src/models/interfaces/EquipmentList.ts
@@ -27,8 +27,8 @@ export interface EquipmentListHeading extends BaseEntityWithName {
 }
 export interface EquipmentListEntry extends BaseEntityWithName {
     sortIndex: number;
-    equipment?: Equipment;
-    equipmentId?: number;
+    equipment?: Equipment | null;
+    equipmentId?: number | null;
     name: string;
     description: string;
 
@@ -37,7 +37,7 @@ export interface EquipmentListEntry extends BaseEntityWithName {
 
     pricePerUnit: currency;
     pricePerHour: currency;
-    equipmentPrice?: EquipmentPrice;
+    equipmentPrice?: EquipmentPrice | null;
     discount: currency;
     isHidden: boolean;
     account: string | null;

--- a/src/models/objection-models/BookingObjectionModel.ts
+++ b/src/models/objection-models/BookingObjectionModel.ts
@@ -267,7 +267,7 @@ export interface IEquipmentListEntryObjectionModel extends BaseObjectionModelWit
 
     sortIndex: number;
     equipment?: IEquipmentObjectionModel;
-    equipmentId?: number;
+    equipmentId?: number | null;
     name: string;
     description: string;
 


### PR DESCRIPTION
Fix saving removal of equipment connection on equipment list entry.
![image](https://github.com/rneventteknik/backstage2/assets/3681132/03ae22ff-0a51-4a81-b9aa-9e669d91378e)

Previously the connection removal wasn't saved server-side and the connection came back on the next data reload. This is fixed by sending `null` as the equipment id and related properties instead of `undefined` which is striped in the JSON conversion.