### PR TITLE
Feature: Show currently out equipment on front page

### DIFF
--- a/src/components/CurrentlyOutEquipment.tsx
+++ b/src/components/CurrentlyOutEquipment.tsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import Skeleton from 'react-loading-skeleton';
+import useSwr from 'swr';
+import { getResponseContentOrError } from '../lib/utils';
+import { CurrentlyOutEquipmentInfo } from '../models/misc/CurrentlyOutEquipmentInfo';
+import { TableConfiguration, TableDisplay } from './TableDisplay';
+import { Card } from 'react-bootstrap';
+import TableStyleLink from './utils/TableStyleLink';
+
+const EquipmentNameDisplayFn = (x: CurrentlyOutEquipmentInfo) =>
+    x.equipmentId ? <TableStyleLink href={'/equipment/' + x.equipmentId}>{x.name}</TableStyleLink> : <em>{x.name}</em>;
+
+const CurrentlyOutEquipment: React.FC = () => {
+    const { data: currentlyOutEquipmentInfos } = useSwr('/api/equipment/currentlyOut', (url) =>
+        fetch(url).then((response) => getResponseContentOrError<CurrentlyOutEquipmentInfo[]>(response)),
+    );
+
+    if (!currentlyOutEquipmentInfos) {
+        return <Skeleton height={120}></Skeleton>;
+    }
+
+    const tableSettings: TableConfiguration<CurrentlyOutEquipmentInfo> = {
+        entityTypeDisplayName: 'utrustning',
+        defaultSortPropertyName: 'name',
+        defaultSortAscending: true,
+        hideTableFilter: true,
+        hideTableCountControls: true,
+        columns: [
+            {
+                key: 'name',
+                displayName: 'Utrustning',
+                getValue: (x: CurrentlyOutEquipmentInfo) => x.name,
+                getContentOverride: EquipmentNameDisplayFn,
+                textTruncation: true,
+                columnWidth: 300,
+            },
+            {
+                key: 'numberOfUnits',
+                displayName: 'Antal',
+                getValue: (x: CurrentlyOutEquipmentInfo) => x.numberOfUnits,
+                columnWidth: 220,
+            },
+        ],
+    };
+
+    return (
+        <Card className="mb-3">
+            <Card.Header>Utlämnad utrustning</Card.Header>
+            <TableDisplay entities={currentlyOutEquipmentInfos} configuration={tableSettings} />
+        </Card>
+    );
+};
+
+export default CurrentlyOutEquipment;

--- a/src/lib/db-access/equipmentList.ts
+++ b/src/lib/db-access/equipmentList.ts
@@ -43,7 +43,7 @@ export const fetchEquipmentListsForBooking = async (bookingId: number): Promise<
     return EquipmentListObjectionModel.query().where('bookingId', bookingId).orderBy('id');
 };
 
-export const fetchOutEquipmentLists = async (): Promise<any[]> => {
+export const fetchOutEquipmentLists = async (): Promise<EquipmentListObjectionModel[]> => {
     ensureDatabaseIsInitialized();
     const now = new Date();
 

--- a/src/models/misc/CurrentlyOutEquipmentInfo.ts
+++ b/src/models/misc/CurrentlyOutEquipmentInfo.ts
@@ -1,0 +1,6 @@
+export interface CurrentlyOutEquipmentInfo {
+    id: number;
+    equipmentId?: number;
+    name: string;
+    numberOfUnits: number;
+}

--- a/src/pages/api/equipment/currentlyOut.ts
+++ b/src/pages/api/equipment/currentlyOut.ts
@@ -1,0 +1,52 @@
+import { NextApiRequest, NextApiResponse } from 'next';
+import { respondWithCustomErrorMessage, respondWithEntityNotFoundResponse } from '../../../lib/apiResponses';
+import { withSessionContext } from '../../../lib/sessionContext';
+import { fetchOutEquipmentLists } from '../../../lib/db-access/equipmentList';
+import { EquipmentList } from '../../../models/interfaces/EquipmentList';
+import { groupBy, reduceSumFn } from '../../../lib/utils';
+
+const handler = async (req: NextApiRequest, res: NextApiResponse): Promise<Promise<void> | void> => {
+    switch (req.method) {
+        case 'GET':
+            await fetchOutEquipmentLists()
+                .then(getEquipmentFromLists)
+                .then((result) => res.status(200).json(result))
+                .catch((error) => respondWithCustomErrorMessage(res, error.message));
+
+            return;
+
+        default:
+            respondWithEntityNotFoundResponse(res);
+    }
+
+    return;
+};
+
+export default handler;
+
+const getEquipmentFromLists = (equipmentLists: EquipmentList[]) => {
+    const listEntries = equipmentLists.flatMap((list) => [
+        ...list.listEntries,
+        ...list.listHeadings.flatMap((heading) => heading.listEntries),
+    ]);
+
+    const equipmentGroupings = groupBy(
+        listEntries.filter((x) => x.equipmentId),
+        (x) => x.equipmentId?.toString() ?? '0',
+    );
+    const equipmentWithCount = Object.keys(equipmentGroupings).map((key) => {
+        const records = equipmentGroupings[key];
+        return {
+            equipmentId: key,
+            id: records[0].id,
+            name: records[0].equipment?.name,
+            numberOfUnits: records.map((x) => x.numberOfUnits).reduce(reduceSumFn, 0),
+        };
+    });
+
+    const customRows = listEntries
+        .filter((x) => !x.equipment)
+        .map((x) => ({ name: x.name, id: x.id, numberOfUnits: x.numberOfUnits }));
+
+    return [...equipmentWithCount, ...customRows];
+};

--- a/src/pages/api/equipment/currentlyOut.ts
+++ b/src/pages/api/equipment/currentlyOut.ts
@@ -2,10 +2,10 @@ import { NextApiRequest, NextApiResponse } from 'next';
 import { respondWithCustomErrorMessage, respondWithEntityNotFoundResponse } from '../../../lib/apiResponses';
 import { withSessionContext } from '../../../lib/sessionContext';
 import { fetchOutEquipmentLists } from '../../../lib/db-access/equipmentList';
-import { EquipmentList } from '../../../models/interfaces/EquipmentList';
 import { groupBy, reduceSumFn } from '../../../lib/utils';
+import { EquipmentListObjectionModel } from '../../../models/objection-models/BookingObjectionModel';
 
-const handler = async (req: NextApiRequest, res: NextApiResponse): Promise<Promise<void> | void> => {
+const handler = withSessionContext(async (req: NextApiRequest, res: NextApiResponse): Promise<Promise<void> | void> => {
     switch (req.method) {
         case 'GET':
             await fetchOutEquipmentLists()
@@ -20,11 +20,11 @@ const handler = async (req: NextApiRequest, res: NextApiResponse): Promise<Promi
     }
 
     return;
-};
+});
 
 export default handler;
 
-const getEquipmentFromLists = (equipmentLists: EquipmentList[]) => {
+const getEquipmentFromLists = (equipmentLists: EquipmentListObjectionModel[]) => {
     const listEntries = equipmentLists.flatMap((list) => [
         ...list.listEntries,
         ...list.listHeadings.flatMap((heading) => heading.listEntries),

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -21,6 +21,7 @@ import Link from 'next/link';
 import { IfNotReadonly } from '../components/utils/IfAdmin';
 import TableStyleLink from '../components/utils/TableStyleLink';
 import { KeyValue } from '../models/interfaces/KeyValue';
+import CurrentlyOutEquipment from '../components/CurrentlyOutEquipment';
 
 // eslint-disable-next-line react-hooks/rules-of-hooks
 export const getServerSideProps = useUserWithDefaultAccessAndWithSettings();
@@ -74,6 +75,7 @@ const IndexPage: React.FC<Props> = ({ user: currentUser, globalSettings }: Props
                         bookings={outBookings}
                         showDateHeadings={false}
                     ></TinyBookingTable>
+                    <CurrentlyOutEquipment />
                     <Card className="mb-3">
                         <Card.Header className="d-flex">
                             <span className="flex-grow-1">Aktivitet</span>


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/366fcd5e-a8d8-4cfc-831b-bad4e995a5f3)

Show a list of currently out equipment on first page. To be more specific, two things are shown:

* Equipment which belongs to an equipment list on a rental booking with status out - i.e. equipment which is on a rental.
* Equipment which belongs to an equipment list on a gig booking which takes place now (either usage dates or equipment out dates)