### PR TITLE
Feature: Admin slack messages

### DIFF
--- a/src/components/admin/SendMessageToBookingOwnersButton.tsx
+++ b/src/components/admin/SendMessageToBookingOwnersButton.tsx
@@ -62,7 +62,10 @@ const SendMessageToBookingOwnersButton: React.FC<Props> = ({ bookings }: Props) 
 
     const sendMessageAndClose = () => {
         sendMessage(message, selectedBookingIds);
-        // hide();
+        setActiveTab('step-one');
+        setSelectedBookingIds([]);
+        setMessage('');
+        hide();
     };
 
     if (!bookings) {

--- a/src/components/admin/SendMessageToBookingOwnersButton.tsx
+++ b/src/components/admin/SendMessageToBookingOwnersButton.tsx
@@ -223,7 +223,7 @@ const SendMessageToBookingOwnersButton: React.FC<Props> = ({ bookings }: Props) 
                                                                 overlay={
                                                                     <Tooltip id="1">
                                                                         <strong>
-                                                                            Denna användare har inget slack Id
+                                                                            Denna användare har inget slack-id
                                                                             konfigurerat och kommer inte att få
                                                                             meddelandet.
                                                                         </strong>

--- a/src/components/admin/SendMessageToBookingOwnersButton.tsx
+++ b/src/components/admin/SendMessageToBookingOwnersButton.tsx
@@ -1,0 +1,224 @@
+import React, { useState } from 'react';
+import { Booking } from '../../models/interfaces';
+import { Button, Card, Form, Modal, Tab } from 'react-bootstrap';
+import Skeleton from 'react-loading-skeleton';
+import { faEnvelope } from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import AdminBookingList from './AdminBookingList';
+import { formatTime, toBookingViewModel } from '../../lib/datetimeUtils';
+import { getResponseContentOrError, onlyUniqueById } from '../../lib/utils';
+import UserIcon from '../utils/UserIcon';
+import { useNotifications } from '../../lib/useNotifications';
+
+type Props = {
+    bookings: Booking[];
+};
+
+const SendMessageToBookingOwnersButton: React.FC<Props> = ({ bookings }: Props) => {
+    const [showModal, setShowModal] = useState(false);
+    const [activeTab, setActiveTab] = useState('step-one');
+    const [message, setMessage] = useState('');
+    const [selectedBookingIds, setSelectedBookingIds] = useState<number[]>([]);
+
+    const { showGeneralSuccessMessage, showGeneralDangerMessage } = useNotifications();
+
+    const now = new Date();
+
+    const toggleBookingSelection = (booking: Booking) => {
+        if (selectedBookingIds.includes(booking.id)) {
+            setSelectedBookingIds((ids) => ids.filter((x) => x !== booking.id));
+            return;
+        }
+
+        setSelectedBookingIds((ids) => [...ids, booking.id]);
+    };
+
+    const recipients = bookings
+        .filter((x) => selectedBookingIds.includes(x.id))
+        .map((x) => x.ownerUser!)
+        .filter(onlyUniqueById);
+
+    const hide = () => setShowModal(false);
+
+    const sendMessage = (message: string, bookingIds: number[]) => {
+        const body = { message, bookingIds };
+
+        const request = {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(body),
+        };
+
+        fetch('/api/sendSlackMessage', request)
+            .then((apiResponse) => getResponseContentOrError(apiResponse))
+            .then(() => {
+                showGeneralSuccessMessage('Meddelande skickat!');
+            })
+            .catch((error: Error) => {
+                console.error(error);
+                showGeneralDangerMessage('Fel!', 'Meddelandet kunde inte skickas');
+            });
+    };
+
+    const sendMessageAndClose = () => {
+        sendMessage(message, selectedBookingIds);
+        hide();
+    };
+
+    if (!bookings) {
+        return <Skeleton height={150} className="mb-3" />;
+    }
+
+    return (
+        <>
+            <Button variant="secondary" onClick={() => setShowModal(true)}>
+                <FontAwesomeIcon icon={faEnvelope} className="mr-1" /> Skicka meddelande till bokningsansvariga
+            </Button>
+            <Modal show={showModal} onHide={hide} size="xl">
+                <Modal.Header closeButton>
+                    <Modal.Title>Skicka meddelande till bokningsansvariga</Modal.Title>
+                </Modal.Header>
+                <Modal.Body>
+                    <Tab.Container id="import-equipment-tabs" activeKey={activeTab}>
+                        <Tab.Content>
+                            <Tab.Pane eventKey="step-one">
+                                <Card className="mb-3">
+                                    <Card.Header className="p-1"></Card.Header>
+                                    <Card.Body>
+                                        <div className="d-flex">
+                                            <p className="text-muted flex-grow-1 mb-0">
+                                                <strong>Steg 1 av 3</strong> Välj bokningar vars ansvariga att skicka
+                                                meddelande till.
+                                            </p>
+                                            <Button
+                                                variant="primary"
+                                                onClick={() => setActiveTab('step-two')}
+                                                className="mr-2"
+                                                disabled={selectedBookingIds.length === 0}
+                                            >
+                                                Gå vidare
+                                            </Button>
+                                        </div>
+                                    </Card.Body>
+                                </Card>
+
+                                <AdminBookingList
+                                    bookings={bookings
+                                        .map(toBookingViewModel)
+                                        .filter(
+                                            (b) => b.usageStartDatetime && b.usageStartDatetime?.getTime() < Date.now(),
+                                        )}
+                                    selectedBookingIds={selectedBookingIds}
+                                    onToggleSelect={toggleBookingSelection}
+                                    showHeadings={true}
+                                />
+                            </Tab.Pane>
+                            <Tab.Pane eventKey="step-two">
+                                <Card className="mb-3">
+                                    <Card.Header className="p-1"></Card.Header>
+                                    <Card.Body>
+                                        <div className="d-flex">
+                                            <p className="text-muted flex-grow-1 mb-0">
+                                                <strong>Steg 2 av 3</strong> Skriv meddelande.
+                                            </p>
+                                            <Button
+                                                variant="secondary"
+                                                onClick={() => setActiveTab('step-one')}
+                                                className="mr-2"
+                                            >
+                                                Gå tillbaka
+                                            </Button>
+                                            <Button
+                                                variant="primary"
+                                                onClick={() => setActiveTab('step-three')}
+                                                className="mr-2"
+                                                disabled={message.length === 0}
+                                            >
+                                                Gå vidare
+                                            </Button>
+                                        </div>
+                                    </Card.Body>
+                                </Card>
+
+                                <Form.Group controlId="formName">
+                                    <Form.Label>Meddelande</Form.Label>
+                                    <Form.Control
+                                        required={true}
+                                        as="textarea"
+                                        name="message"
+                                        rows={6}
+                                        placeholder="En ny månad har börjat och det är dags att klarmarkera bokningar."
+                                        value={message}
+                                        onChange={(e) => setMessage(e.target.value)}
+                                    />
+                                </Form.Group>
+                            </Tab.Pane>
+                            <Tab.Pane eventKey="step-three">
+                                <Card className="mb-3">
+                                    <Card.Header className="p-1"></Card.Header>
+                                    <Card.Body>
+                                        <div className="d-flex">
+                                            <p className="text-muted flex-grow-1 mb-0">
+                                                <strong>Steg 3 av 3</strong> Förhandsgranskning.
+                                            </p>
+                                            <Button
+                                                variant="secondary"
+                                                onClick={() => setActiveTab('step-two')}
+                                                className="mr-2"
+                                            >
+                                                Gå tillbaka
+                                            </Button>
+                                            <Button
+                                                variant="primary"
+                                                onClick={() => sendMessageAndClose()}
+                                                className="mr-2"
+                                            >
+                                                <FontAwesomeIcon icon={faEnvelope} className="mr-1" /> Skicka meddelande
+                                            </Button>
+                                        </div>
+                                    </Card.Body>
+                                </Card>
+
+                                <Card className="mb-3">
+                                    <Card.Header>Förhandsgranskning av meddelande</Card.Header>
+                                    <Card.Body>
+                                        <div className="d-flex">
+                                            <div className="p-2">
+                                                <UserIcon user={{ userId: 9, isLoggedIn: false }} />
+                                            </div>
+                                            <div className="w-100">
+                                                <p className="mb-0">
+                                                    <strong>Backstage2</strong> {formatTime(now)}
+                                                </p>
+                                                <p>{message}</p>
+                                                <hr />
+                                                Angående bokningar:
+                                                <ul>
+                                                    <li>Exempelbokning 1</li>
+                                                    <li>Exempelbokning 2</li>
+                                                </ul>
+                                            </div>
+                                        </div>
+                                    </Card.Body>
+                                </Card>
+
+                                <Card className="mb-3">
+                                    <Card.Header>Mottagare</Card.Header>
+                                    <Card.Body>
+                                        <ul>
+                                            {recipients.map((x) => (
+                                                <li key={x.id}>{x.name}</li>
+                                            ))}
+                                        </ul>
+                                    </Card.Body>
+                                </Card>
+                            </Tab.Pane>
+                        </Tab.Content>
+                    </Tab.Container>
+                </Modal.Body>
+            </Modal>
+        </>
+    );
+};
+
+export default SendMessageToBookingOwnersButton;

--- a/src/components/bookings/timeEstimate/TimeEstimateAddButton.tsx
+++ b/src/components/bookings/timeEstimate/TimeEstimateAddButton.tsx
@@ -24,8 +24,7 @@ const TimeEstimateAddButton: React.FC<Props & React.ComponentProps<typeof Button
     ...rest
 }: Props & React.ComponentProps<typeof Button>) => {
     const [timeEstimateViewModel, setTimeEstimateViewModel] = useState<Partial<TimeEstimate> | undefined>(undefined);
-    const { showCreateSuccessNotification, showCreateFailedNotification } =
-        useNotifications();
+    const { showCreateSuccessNotification, showCreateFailedNotification } = useNotifications();
 
     const addTimeEstimate = async (timeEstimate: ITimeEstimateObjectionModel) => {
         addTimeEstimateApiCall(timeEstimate, booking.id)

--- a/src/components/bookings/timeReport/TimeReportAddButton.tsx
+++ b/src/components/bookings/timeReport/TimeReportAddButton.tsx
@@ -26,13 +26,12 @@ const TimeReportAddButton: React.FC<Props & React.ComponentProps<typeof Button>>
     ...rest
 }: Props & React.ComponentProps<typeof Button>) => {
     const [timeReport, setTimeReport] = useState<Partial<TimeReport> | undefined>(undefined);
-    const { showCreateSuccessNotification, showCreateFailedNotification } =
-        useNotifications();
+    const { showCreateSuccessNotification, showCreateFailedNotification } = useNotifications();
 
     const addTimeReport = (timeReport: ITimeReportObjectionModel) => {
         addTimeReportApiCall(timeReport, booking.id)
             .then((data) => {
-                showCreateSuccessNotification("Tidrapporten");
+                showCreateSuccessNotification('Tidrapporten');
                 onAdd(data);
             })
             .catch((error: Error) => {

--- a/src/lib/slack.ts
+++ b/src/lib/slack.ts
@@ -15,6 +15,25 @@ export const sendSlackMessage = async (message: string, channelId: string) => {
     }
 };
 
+export const sendSlackMessageToUserRegardingBookings = async (
+    message: string,
+    bookings: { id: number; name: string }[],
+    userSlackId: string,
+) => {
+    const bookingList = bookings.map((x) => {
+        const bookingUrl = process.env.APPLICATION_BASE_URL + '/bookings/' + x.id;
+        return `>- <${bookingUrl}|${x.name}>\n`;
+    });
+
+    const formattedMessage = `${message}\n\n>Angående bokningar:\n${bookingList.join('')}`;
+
+    if (!userSlackId) {
+        throw new Error('Invalid slack channel id');
+    }
+
+    sendSlackMessage(formattedMessage, userSlackId);
+};
+
 export const sendSlackMessageForBooking = async (
     message: string,
     bookingId: number,

--- a/src/pages/admin-overview.tsx
+++ b/src/pages/admin-overview.tsx
@@ -11,6 +11,7 @@ import { Role } from '../models/enums/Role';
 import AdminBookingList from '../components/admin/AdminBookingList';
 import { toBookingViewModel } from '../lib/datetimeUtils';
 import { KeyValue } from '../models/interfaces/KeyValue';
+import SendMessageToBookingOwnersButton from '../components/admin/SendMessageToBookingOwnersButton';
 
 // eslint-disable-next-line react-hooks/rules-of-hooks
 export const getServerSideProps = useUserWithDefaultAccessAndWithSettings(Role.ADMIN);
@@ -42,7 +43,8 @@ const AdminOverviewPage: React.FC<Props> = ({ user: currentUser, globalSettings 
     return (
         <Layout title={pageTitle} currentUser={currentUser} globalSettings={globalSettings}>
             <Header title={pageTitle} breadcrumbs={breadcrumbs}></Header>
-            <p className="text-muted">
+            <SendMessageToBookingOwnersButton bookings={bookingsToShow} />
+            <p className="text-muted mt-2">
                 I listan nedan visas endast bokningar vars startdatum har passerats, dvs inga bokningar framåt i tiden.
             </p>
             <AdminBookingList bookings={bookingsToShow} showHeadings={true} />


### PR DESCRIPTION
Allow admins to send slack messages to owners of bookings. The primary use case for this is to remind people to update the statuses for their bookings without having to manually generate a list of users to message and manually contacting them.

---

![image](https://github.com/user-attachments/assets/fe2daf90-fd1b-4afc-9ae7-9c842450da5d)
![image](https://github.com/user-attachments/assets/a080fe44-918a-4056-bb05-8634a691fa98)
![image](https://github.com/user-attachments/assets/b1ae14b0-2543-4931-97b0-d5fb43ca1e69)
![image](https://github.com/user-attachments/assets/1a635803-4116-4bdb-abf9-fb187400e89c)
![image](https://github.com/user-attachments/assets/8962e656-9495-42ac-acdb-3b81a4582274)

---

Resolves #54 