### PR TITLE
Feature: Add wizard to fetch list times from calendar

### DIFF
--- a/src/components/bookings/equipmentLists/EditEquipmentListDatesModal.tsx
+++ b/src/components/bookings/equipmentLists/EditEquipmentListDatesModal.tsx
@@ -199,6 +199,7 @@ const EditEquipmentListDatesModal: React.FC<Props> = ({ show, onHide, equipmentL
                                             type="submit"
                                             variant="secondary"
                                             className="ml-2"
+                                            disabled={!wizardSelectedCalendarEvent}
                                         >
                                             Hämta
                                         </Button>


### PR DESCRIPTION
This is a bit of an experiment which I am still not sure if I like, but I would like some input from others.

We have a few bookings each year where each equipment list actually represent different events, primarily during the receptions but also for spexes with multiple rehearsals etc. If you have a lot of equipment lists it can be quite a hassle to input the wildly different times for each equipment list manually, which often is made extra frustrating since that data is already available in the calendar but cannot be imported in any way.

We have already decided that we do not want to change the primary connection between a booking in stage and an calendar event, but I wanted to test a looser connection in the form of a one-off fetch-from-calendar-action, similar to the calendar integration for equipment in/out times. From a UX perspective I built this in the style of the time estimate wizard, which has a very similar behavior for the user: an optional way to fill in the form which may be very useful in some cases but also cannot be used in all cases.

My opinion so far is, I think, that I like the behavior, but I do not like how cluttered the dialog becomes. It is hard to find the primary controls. If there are any suggestions for how to model the UX of the dialog in a better way, I would appreciate them. For now, I went with the "when in doubt, make it similar to other things" path and made it as identical to the time estimate wizard as possible. 

---

![image](https://github.com/user-attachments/assets/d1f1e4a1-2cfe-43c4-b3e6-5deddacab037)

![image](https://github.com/user-attachments/assets/0a916f00-d19a-4176-bb0f-e15915b7c9d8)

![image](https://github.com/user-attachments/assets/ea66d62e-6523-4511-aa5c-3eac699c7348)
