### PR TITLE
Feature: Show customers other bookings on booking page

### DIFF
--- a/src/components/bookings/PreviousBookingsCard.tsx
+++ b/src/components/bookings/PreviousBookingsCard.tsx
@@ -1,0 +1,105 @@
+import React, { useState } from 'react';
+import { Button, Card, ListGroup } from 'react-bootstrap';
+import { toBookingViewModel } from '../../lib/datetimeUtils';
+import useSwr from 'swr';
+import {
+    faAngleDown,
+    faAngleUp,
+    faExclamationCircle,
+    faInfoCircle,
+} from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import TableStyleLink from '../utils/TableStyleLink';
+import Skeleton from 'react-loading-skeleton';
+import { bookingsFetcher } from '../../lib/fetchers';
+import { getSortedList } from '../../lib/sortIndexUtils';
+
+type Props = {
+    hogiaId: number | null;
+    bookingId: number;
+};
+
+const PreviousBookingsCard: React.FC<Props> = ({ hogiaId, bookingId }: Props) => {
+    const [showContent, setShowContent] = useState(true);
+
+    if (hogiaId === null) {
+        return (
+            <Card className="mb-3">
+                <Card.Header>Andra bokningar för kund</Card.Header>
+                <Card.Body>
+                    <p className="text-muted mb-0"><FontAwesomeIcon icon={faInfoCircle} className='mr-2'/>Endast tillgängligt för kunder med Hogia Id.</p>
+                </Card.Body>
+            </Card>
+        );
+    }
+
+    return (
+        <>
+            <Card className="mb-3">
+                <Card.Header className="d-flex">
+                <span className='flex-grow-1'>Andra bokningar för kund</span>
+                    <Button className="mr-2" variant="" size="sm" onClick={() => setShowContent((x) => !x)}>
+                        <FontAwesomeIcon icon={showContent ? faAngleUp : faAngleDown} />
+                    </Button>
+                </Card.Header>
+                {showContent ? <PreviousBookingsCardList hogiaId={hogiaId} bookingId={bookingId}/> : null}
+            </Card>
+        </>
+    );
+};
+
+type PreviousBookingsCardProps = {
+    hogiaId: number | null;
+    bookingId: number;
+};
+
+const PreviousBookingsCardList: React.FC<PreviousBookingsCardProps> = ({ hogiaId, bookingId }: PreviousBookingsCardProps) => {
+    const { data: list, error } = useSwr('/api/bookings', bookingsFetcher);
+
+    // Error handling
+    //
+    if (error) {
+        return (
+            <div className="p-3">
+                <p className="text-danger">
+                    <FontAwesomeIcon icon={faExclamationCircle} /> Det gick inte att ladda bokningarna.
+                </p>
+                <p className="text-monospace text-muted mb-0">{error.message}</p>
+            </div>
+        );
+    }
+
+    // Loading skeleton
+    //
+    if (!list) {
+        return <Skeleton height={150} className="mb-3" />;
+    }
+
+    const bookingViewModels = list
+        .filter((x) => x.invoiceHogiaId === hogiaId)
+        .filter((x) => x.id !== bookingId)
+        .map(toBookingViewModel)
+        .map((x) => ({ ...x, sortIndex: -(x.usageStartDatetime?.getTime() ?? 0) }));
+
+    const sortedBookingViewModels = getSortedList(bookingViewModels);
+
+    // List
+    //
+    return (
+        <ListGroup variant="flush">
+            {sortedBookingViewModels.map((booking) => (
+                <ListGroup.Item key={booking.id}>
+                    <TableStyleLink href={'/bookings/' + booking.id}>{booking.name}</TableStyleLink>
+                    <p className="mb-0 text-muted">{booking.monthYearUsageStartString}</p>
+                </ListGroup.Item>
+            ))}
+            {sortedBookingViewModels.length === 0 ? (
+                <ListGroup.Item className="text-center font-italic text-muted">
+                    Denna kund har inga andra bokningar.
+                </ListGroup.Item>
+            ) : null}
+        </ListGroup>
+    );
+};
+
+export default PreviousBookingsCard;

--- a/src/components/bookings/PreviousBookingsCard.tsx
+++ b/src/components/bookings/PreviousBookingsCard.tsx
@@ -34,17 +34,15 @@ const PreviousBookingsCard: React.FC<Props> = ({ hogiaId, bookingId }: Props) =>
     }
 
     return (
-        <>
-            <Card className="mb-3">
-                <Card.Header className="d-flex">
-                <span className='flex-grow-1'>Andra bokningar för kund</span>
-                    <Button className="mr-2" variant="" size="sm" onClick={() => setShowContent((x) => !x)}>
-                        <FontAwesomeIcon icon={showContent ? faAngleUp : faAngleDown} />
-                    </Button>
-                </Card.Header>
-                {showContent ? <PreviousBookingsCardList hogiaId={hogiaId} bookingId={bookingId}/> : null}
-            </Card>
-        </>
+        <Card className="mb-3">
+            <Card.Header className="d-flex">
+            <span className='flex-grow-1'>Andra bokningar för kund</span>
+                <Button className="mr-2" variant="" size="sm" onClick={() => setShowContent((x) => !x)}>
+                    <FontAwesomeIcon icon={showContent ? faAngleUp : faAngleDown} />
+                </Button>
+            </Card.Header>
+            {showContent ? <PreviousBookingsCardList hogiaId={hogiaId} bookingId={bookingId}/> : null}
+        </Card>
     );
 };
 

--- a/src/pages/bookings/[id]/index.tsx
+++ b/src/pages/bookings/[id]/index.tsx
@@ -60,6 +60,7 @@ import ConfirmModal from '../../../components/utils/ConfirmModal';
 import BookingInfoSection from '../../../components/bookings/BookingInfoSection';
 import FilesCard from '../../../components/bookings/FilesCard';
 import currency from 'currency.js';
+import PreviousBookingsCard from '../../../components/bookings/PreviousBookingsCard';
 
 // eslint-disable-next-line react-hooks/rules-of-hooks
 export const getServerSideProps = useUserWithDefaultAccessAndWithSettings();
@@ -520,13 +521,13 @@ const BookingPage: React.FC<Props> = ({ user: currentUser, globalSettings }: Pro
                         onSubmit={(driveFolderId) => saveBooking({ driveFolderId })}
                         readonly={readonly}
                     />
-
                     <MarkdownCard
                         text={booking.returnalNote}
                         onSubmit={(returnalNote) => saveBooking({ returnalNote })}
                         cardTitle="Återlämningsanmärkning"
                         readonly={readonly}
                     />
+                    <PreviousBookingsCard hogiaId={booking.invoiceHogiaId} bookingId={booking.id}/>
                     <ChangelogCard changelog={booking.changelog ?? []} />
                 </Col>
             </Row>


### PR DESCRIPTION
Add a list on the booking page showing the customers previous bookings. This is done by matching on Hogia Id. 

If the booking does not have a Hogia Id a message is shown that this feature only works for customers with Hogia Ids.

For now, this list works the same way as the lists on the front page - i.e. all bookings are fetched and the filtering is done client side.

Note: I opted to not show booking statuses, type, etc here since it made the UX very cluttered, but maybe it's worth the clutter to get that information and to be consistent?

---

![image](https://github.com/user-attachments/assets/dac43473-eb87-447f-bd87-d581d5a623e4)

![image](https://github.com/user-attachments/assets/97a34017-1d37-47c9-b883-f5d6a74e29bd)

![image](https://github.com/user-attachments/assets/55d0ca90-41f0-4017-87de-17a88e287e76)
