### PR TITLE
Feature: Add rental terms link to documents

### DIFF
--- a/src/document-templates/components/priceEstimateDocument.tsx
+++ b/src/document-templates/components/priceEstimateDocument.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Booking } from '../../models/interfaces';
-import { Page, View, Text, Document } from '@react-pdf/renderer';
+import { Page, View, Text, Document, Link } from '@react-pdf/renderer';
 import { commonStyles } from '../utils';
 import { BookingInfo } from './shared/bookingInfo';
 import { PageCount } from './shared/pageCount';
@@ -51,7 +51,10 @@ export const PriceEstimateDocument: React.FC<Props> = ({ booking, globalSettings
                         priceByAgreement={!showPrices}
                     />
                     <Text style={styles.bold}>{t('price-estimate.legal-note.title')}</Text>
-                    <Text>{t('price-estimate.legal-note.content')}</Text>
+                    <Text>
+                        {t('price-estimate.legal-note.content')}{' '}
+                        <Link src={t('price-estimate.legal-note.url')}>{t('price-estimate.legal-note.url')}</Link>
+                    </Text>
                 </MainContent>
 
                 <Footer booking={booking} />

--- a/src/document-templates/components/priceEstimateDocument.tsx
+++ b/src/document-templates/components/priceEstimateDocument.tsx
@@ -53,7 +53,7 @@ export const PriceEstimateDocument: React.FC<Props> = ({ booking, globalSettings
                     <Text style={styles.bold}>{t('price-estimate.legal-note.title')}</Text>
                     <Text>
                         {t('price-estimate.legal-note.content')}{' '}
-                        <Link src={t('price-estimate.legal-note.url')}>{t('price-estimate.legal-note.url')}</Link>
+                        <Link src={t('price-estimate.legal-note.url')}>{t('price-estimate.legal-note.shown-url')}</Link>
                     </Text>
                 </MainContent>
 

--- a/src/document-templates/components/rentalConfirmationDocument.tsx
+++ b/src/document-templates/components/rentalConfirmationDocument.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Booking } from '../../models/interfaces';
-import { Page, View, Text, Document } from '@react-pdf/renderer';
+import { Page, View, Text, Document, Link } from '@react-pdf/renderer';
 import { commonStyles } from '../utils';
 import { BookingInfo } from './shared/bookingInfo';
 import { PageCount } from './shared/pageCount';
@@ -58,7 +58,12 @@ export const RentalConfirmationDocument: React.FC<Props> = ({ booking, globalSet
                         <Text style={[styles.bold, styles.marginTopLarge]}>
                             {t('rental-agreement.legal-note.title')}
                         </Text>
-                        <Text>{t('rental-agreement.legal-note.content')}</Text>
+                        <Text>
+                            {t('rental-agreement.legal-note.content')}{' '}
+                            <Link src={t('rental-agreement.legal-note.url')}>
+                                {t('rental-agreement.legal-note.url')}
+                            </Link>
+                        </Text>
 
                         <View>
                             <Row>

--- a/src/document-templates/defaultTextResources.ts
+++ b/src/document-templates/defaultTextResources.ts
@@ -49,7 +49,8 @@ export const defaultTextResources: Record<Language, Record<string, string>> = {
         'price-estimate.legal-note.title': 'Observera',
         'price-estimate.legal-note.content':
             'Ovanstående är en prisuppskattning. Det är den faktiska tidsåtgången och använd utrustning som faktureras. Fullständiga hyresvillkor återfinns på',
-        'price-estimate.legal-note.url': 'www.rneventteknik.se/terms',
+        'price-estimate.legal-note.url': 'https://www.rneventteknik.se/terms',
+        'price-estimate.legal-note.shown-url': 'rneventteknik.se/terms',
 
         // Packing list
         'packing-list.filename': 'Packlista',
@@ -145,7 +146,8 @@ export const defaultTextResources: Record<Language, Record<string, string>> = {
         'price-estimate.legal-note.title': 'Please observe',
         'price-estimate.legal-note.content':
             'The above is a price estimate. It is the actual time required and used equipment that is invoiced. Term and conditions are available at',
-        'price-estimate.legal-note.url': 'www.rneventteknik.se/terms',
+        'price-estimate.legal-note.url': 'https://www.rneventteknik.se/terms',
+        'price-estimate.legal-note.shown-url': 'rneventteknik.se/terms',
 
         // Packing list
         'packing-list.filename': 'Packing List',

--- a/src/document-templates/defaultTextResources.ts
+++ b/src/document-templates/defaultTextResources.ts
@@ -48,7 +48,8 @@ export const defaultTextResources: Record<Language, Record<string, string>> = {
         'price-estimate.title': 'Prisuppskattning',
         'price-estimate.legal-note.title': 'Observera',
         'price-estimate.legal-note.content':
-            'Ovanstående är en prisuppskattning. Det är den faktiska tidsåtgången och använd utrustning som faktureras. Ni som arrangör ansvarar för att utrustningen inte blir stulen eller förstörd.',
+            'Ovanstående är en prisuppskattning. Det är den faktiska tidsåtgången och använd utrustning som faktureras. Fullständiga hyresvillkor återfinns på',
+        'price-estimate.legal-note.url': 'www.rneventteknik.se/terms',
 
         // Packing list
         'packing-list.filename': 'Packlista',
@@ -59,7 +60,8 @@ export const defaultTextResources: Record<Language, Record<string, string>> = {
         'rental-agreement.title': 'Hyresavtal',
         'rental-agreement.legal-note.title': 'Hyresvillkor',
         'rental-agreement.legal-note.content':
-            'Utrustningen skall lämnas tillbaka i det skick och nedpackat på samma vis som den hämtades i. Detta innebär att alla kablar skall rullas ihop snyggt och om något blivit smutsigt, kladdigt eller lämnats kvar tejprester på skall detta göras rent.',
+            'Genom att signera detta avtal godkänner Hyrestagaren villkoren som återfinns på',
+        'rental-agreement.legal-note.url': 'www.rneventteknik.se/terms',
         'rental-agreement.signature.1': 'Namnteckning:',
         'rental-agreement.signature.2': 'Datum:',
         'rental-agreement.signature.3': 'Ort:',
@@ -142,7 +144,8 @@ export const defaultTextResources: Record<Language, Record<string, string>> = {
         'price-estimate.title': 'Price estimate',
         'price-estimate.legal-note.title': 'Please observe',
         'price-estimate.legal-note.content':
-            'The above is a price estimate. It is the actual time required and used equipment that is invoiced. You as the organizer are responsible for ensuring that the equipment is not stolen or destroyed',
+            'The above is a price estimate. It is the actual time required and used equipment that is invoiced. Term and conditions are available at',
+        'price-estimate.legal-note.url': 'www.rneventteknik.se/terms',
 
         // Packing list
         'packing-list.filename': 'Packing List',
@@ -153,7 +156,8 @@ export const defaultTextResources: Record<Language, Record<string, string>> = {
         'rental-agreement.title': 'Rental agreement',
         'rental-agreement.legal-note.title': 'Rental conditions',
         'rental-agreement.legal-note.content':
-            'The equipment shall be returned in the same condition and packed in the same wat as it was picked up in. All cabled should be neatly rolled and if anything has become dirty or sticky it must be cleaned.',
+            'By signing this agreement the Lessee is accepting the terms and conditions found at',
+        'rental-agreement.legal-note.url': 'www.rneventteknik.se/terms',
         'rental-agreement.signature.1': 'Signature:',
         'rental-agreement.signature.2': 'Date:',
         'rental-agreement.signature.3': 'Place:',


### PR DESCRIPTION
Price estimate and rental agreement now links to the terms and conditions page on our website.
<img width="741" alt="Screenshot 2024-08-21 at 00 59 55" src="https://github.com/user-attachments/assets/7a74ff9e-5e17-4c54-9df8-98aa1344ff1f">
<img width="741" alt="Screenshot 2024-08-21 at 01 02 39" src="https://github.com/user-attachments/assets/e3857afc-c122-44d9-9839-e661b06cea09">

