### PR TITLE
Bugfix: Fix unintended reorder of time reports and estimates on advanced edit

### DIFF
--- a/src/components/bookings/timeEstimate/TimeEstimateList.tsx
+++ b/src/components/bookings/timeEstimate/TimeEstimateList.tsx
@@ -331,7 +331,7 @@ const TimeEstimateList: React.FC<Props> = ({ bookingId, readonly, defaultLaborHo
                             numberOfHours: timeEstimateToEditViewModel?.numberOfHours ?? 0,
                             pricePerHour: timeEstimateToEditViewModel?.pricePerHour ?? currency(0),
                             name: timeEstimateToEditViewModel?.name ?? '',
-                            sortIndex: getNextSortIndex(booking.timeEstimates ?? []),
+                            sortIndex: timeEstimateToEditViewModel.sortIndex ?? getNextSortIndex(booking.timeEstimates ?? []),
                         };
                         updateTimeEstimates(timeEstimateToSend);
                     }

--- a/src/components/bookings/timeReport/TimeReportModal.tsx
+++ b/src/components/bookings/timeReport/TimeReportModal.tsx
@@ -65,7 +65,7 @@ const TimeReportModal: React.FC<Props> = ({
             endDatetime: timeReport?.endDatetime?.toISOString() ?? '',
             pricePerHour: timeReport?.pricePerHour?.value ?? 0,
             name: timeReport?.name ?? '',
-            sortIndex: getNextSortIndex(booking.timeReports ?? []),
+            sortIndex: timeReport?.sortIndex ?? getNextSortIndex(booking.timeReports ?? []),
         };
 
         onSubmit(timeReportToSend);


### PR DESCRIPTION
Fix unintended reorder of time reports and estimates to end of list when using advanced edit.