### PR TITLE
Feature: Record sent admin messages in changelog

### DIFF
--- a/src/lib/changelogUtils.ts
+++ b/src/lib/changelogUtils.ts
@@ -205,6 +205,16 @@ export const logPaymentStatusChangeToBooking = (
     return addChangelogToBooking(message, bookingId, 0);
 };
 
+export const logMessageSentToBookingOwner = (
+    user: CurrentUserInfo,
+    bookingId: number,
+    bookingOwner: string,
+) => {
+    const message = `${user.name} skickade ett meddelande till ansvarig ${bookingOwner}.`;
+
+    return addChangelogToBooking(message, bookingId);
+};
+
 // Equipment
 //
 


### PR DESCRIPTION
Sent admin DMs to booking owners are now recorded in booking change log. Note that the message content is not stored, only the fact that a message was sent - through I think we should discuss if we want to record/show the message content as well.

---

![image](https://github.com/user-attachments/assets/84e905d8-265b-497c-a8cf-0160f608ecc5)

