### PR TITLE
Feature: Remove warning for both fixed price and time reports

### DIFF
--- a/src/components/admin/AdminBookingList.tsx
+++ b/src/components/admin/AdminBookingList.tsx
@@ -1,4 +1,4 @@
-import { faCircleInfo, faWarning } from '@fortawesome/free-solid-svg-icons';
+import { faCircleInfo } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import React from 'react';
 import { OverlayTrigger, Tooltip } from 'react-bootstrap';
@@ -122,22 +122,6 @@ const AdminBookingList: React.FC<Props> = ({
                         }
                     >
                         <FontAwesomeIcon icon={faCircleInfo} className="mr-1" title="" />
-                    </OverlayTrigger>
-                ) : null}
-
-                {booking.fixedPrice !== null && booking.fixedPrice > 0 && (booking.timeReports?.length ?? 0) > 0 ? (
-                    <OverlayTrigger
-                        placement="right"
-                        overlay={
-                            <Tooltip id="1">
-                                <strong>
-                                    Denna bokning har både fast pris och tidrapporter. Detta stödjs inte av Stage
-                                    fakturaexporter och bokningen behöver därför faktureras manuellt.
-                                </strong>
-                            </Tooltip>
-                        }
-                    >
-                        <FontAwesomeIcon icon={faWarning} className="mr-1 text-danger" title="" />
                     </OverlayTrigger>
                 ) : null}
 


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/dcea9535-fabe-473d-86aa-1975dfc290ee)

This works now (as of #56) so no warning is needed.

---
Resolves #94 