### PR TITLE
Feature: UX to encourage users to set equipment dates

### DIFF
--- a/src/components/bookings/BookingStatusButton.tsx
+++ b/src/components/bookings/BookingStatusButton.tsx
@@ -120,6 +120,7 @@ const BookingStatusModal: React.FC<BookingStatusModalProps> = ({
         hide();
         onChange(booking);
     };
+
     return (
         <Modal show={show} onHide={hide} size="lg" backdrop="static">
             <Modal.Header closeButton>

--- a/src/components/bookings/BookingStatusButton.tsx
+++ b/src/components/bookings/BookingStatusButton.tsx
@@ -126,6 +126,15 @@ const BookingStatusModal: React.FC<BookingStatusModalProps> = ({
                 <Modal.Title>Verifiera bokningsinformationen</Modal.Title>
             </Modal.Header>
             <Modal.Body className="was-validated">
+                {(booking.status === Status.DONE || booking.status === Status.BOOKED) &&
+                booking.bookingType === BookingType.RENTAL &&
+                equipmentLists &&
+                equipmentLists.some((x) => !x.equipmentOutDatetime) ? (
+                    <Alert variant="danger">
+                        Den här bokningen har utrustningslistor utan in- och utlämningstider. Är du säker på att du vill
+                        markera den som bokad?
+                    </Alert>
+                ) : null}
                 {booking.status === Status.DONE &&
                 booking.bookingType === BookingType.GIG &&
                 timeReports &&

--- a/src/components/bookings/equipmentLists/EquipmentListHeader.tsx
+++ b/src/components/bookings/equipmentLists/EquipmentListHeader.tsx
@@ -111,6 +111,18 @@ const EquipmentListHeader: React.FC<Props> = ({
         list.equipmentOutDatetime ||
         list.equipmentInDatetime;
 
+    const getEquipmentDateColor = (list: EquipmentList) => {
+        if (!!list.equipmentOutDatetime) {
+            return '';
+        }
+
+        if (bookingStatus === Status.BOOKED) {
+            return 'text-danger';
+        }
+
+        return 'text-muted';
+    };
+
     // HTML template
     //
     return (
@@ -473,7 +485,7 @@ const EquipmentListHeader: React.FC<Props> = ({
                         <Col md={3} xs={6}>
                             <small>Utlämning</small>
                             <div
-                                className={'mb-3 ' + (!!list.equipmentOutDatetime ? '' : 'text-muted')}
+                                className={'mb-3 ' + getEquipmentDateColor(list)}
                                 style={{ fontSize: '1.2em' }}
                                 title={formatDatetimeForForm(getEquipmentOutDatetime(list))}
                             >
@@ -483,7 +495,7 @@ const EquipmentListHeader: React.FC<Props> = ({
                         <Col md={3} xs={6}>
                             <small>Återlämning</small>
                             <div
-                                className={'mb-3 ' + (!!list.equipmentOutDatetime ? '' : 'text-muted')}
+                                className={'mb-3 ' + getEquipmentDateColor(list)}
                                 style={{ fontSize: '1.2em' }}
                                 title={formatDatetimeForForm(getEquipmentInDatetime(list))}
                             >


### PR DESCRIPTION
Improve UX to encourage users to set dates for equipment in and out.

* New warning when setting rentals to booked if any list is missing configured dates.
* Booked rentals now have the default dates (i.e. usage start and usage end) in red instead of gray if configured equipment in and out dates are missing.

![image](https://github.com/user-attachments/assets/75b1b20b-c7ee-43c2-9876-e71009577b65)
![image](https://github.com/user-attachments/assets/5b2682d1-521a-4710-81f7-9331697ce26a)

---
Resolves #79