### PR TITLE
Bugfix: Improve send message to booking owners performance

### DIFF
--- a/src/components/admin/SendMessageToBookingOwnersButton.tsx
+++ b/src/components/admin/SendMessageToBookingOwnersButton.tsx
@@ -1,17 +1,17 @@
 import React, { useState } from 'react';
-import { Booking } from '../../models/interfaces';
+import { Booking, BookingViewModel } from '../../models/interfaces';
 import { Button, Card, Form, Modal, OverlayTrigger, Tab, Tooltip } from 'react-bootstrap';
 import Skeleton from 'react-loading-skeleton';
 import { faEnvelope, faWarning } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import AdminBookingList from './AdminBookingList';
-import { formatTime, toBookingViewModel } from '../../lib/datetimeUtils';
+import { formatTime } from '../../lib/datetimeUtils';
 import { getResponseContentOrError, onlyUniqueById } from '../../lib/utils';
 import UserIcon from '../utils/UserIcon';
 import { useNotifications } from '../../lib/useNotifications';
 
 type Props = {
-    bookings: Booking[];
+    bookings: BookingViewModel[];
 };
 
 const SendMessageToBookingOwnersButton: React.FC<Props> = ({ bookings }: Props) => {
@@ -88,164 +88,175 @@ const SendMessageToBookingOwnersButton: React.FC<Props> = ({ bookings }: Props) 
                     <Tab.Container id="import-equipment-tabs" activeKey={activeTab}>
                         <Tab.Content>
                             <Tab.Pane eventKey="step-one">
-                                <Card className="mb-3">
-                                    <Card.Header className="p-1"></Card.Header>
-                                    <Card.Body>
-                                        <div className="d-flex">
-                                            <p className="text-muted flex-grow-1 mb-0">
-                                                <strong>Steg 1 av 3</strong> Välj bokningar vars ansvariga att skicka
-                                                meddelande till.
-                                            </p>
-                                            <Button
-                                                variant="primary"
-                                                onClick={() => setActiveTab('step-two')}
-                                                className="mr-2"
-                                                disabled={selectedBookingIds.length === 0}
-                                            >
-                                                Gå vidare
-                                            </Button>
-                                        </div>
-                                    </Card.Body>
-                                </Card>
+                                {activeTab === 'step-one' ? (
+                                    <>
+                                        <Card className="mb-3">
+                                            <Card.Header className="p-1"></Card.Header>
+                                            <Card.Body>
+                                                <div className="d-flex">
+                                                    <p className="text-muted flex-grow-1 mb-0">
+                                                        <strong>Steg 1 av 3</strong> Välj bokningar vars ansvariga att
+                                                        skicka meddelande till.
+                                                    </p>
+                                                    <Button
+                                                        variant="primary"
+                                                        onClick={() => setActiveTab('step-two')}
+                                                        className="mr-2"
+                                                        disabled={selectedBookingIds.length === 0}
+                                                    >
+                                                        Gå vidare
+                                                    </Button>
+                                                </div>
+                                            </Card.Body>
+                                        </Card>
 
-                                <AdminBookingList
-                                    bookings={bookings
-                                        .map(toBookingViewModel)
-                                        .filter(
-                                            (b) => b.usageStartDatetime && b.usageStartDatetime?.getTime() < Date.now(),
-                                        )}
-                                    selectedBookingIds={selectedBookingIds}
-                                    onToggleSelect={toggleBookingSelection}
-                                    showHeadings={true}
-                                />
+                                        <AdminBookingList
+                                            bookings={bookings}
+                                            selectedBookingIds={selectedBookingIds}
+                                            onToggleSelect={toggleBookingSelection}
+                                            showHeadings={true}
+                                        />
+                                    </>
+                                ) : null}
                             </Tab.Pane>
                             <Tab.Pane eventKey="step-two">
-                                <Card className="mb-3">
-                                    <Card.Header className="p-1"></Card.Header>
-                                    <Card.Body>
-                                        <div className="d-flex">
-                                            <p className="text-muted flex-grow-1 mb-0">
-                                                <strong>Steg 2 av 3</strong> Skriv meddelande.
-                                            </p>
-                                            <Button
-                                                variant="secondary"
-                                                onClick={() => setActiveTab('step-one')}
-                                                className="mr-2"
-                                            >
-                                                Gå tillbaka
-                                            </Button>
-                                            <Button
-                                                variant="primary"
-                                                onClick={() => setActiveTab('step-three')}
-                                                className="mr-2"
-                                                disabled={message.length === 0}
-                                            >
-                                                Gå vidare
-                                            </Button>
-                                        </div>
-                                    </Card.Body>
-                                </Card>
+                                {activeTab === 'step-two' ? (
+                                    <>
+                                        <Card className="mb-3">
+                                            <Card.Header className="p-1"></Card.Header>
+                                            <Card.Body>
+                                                <div className="d-flex">
+                                                    <p className="text-muted flex-grow-1 mb-0">
+                                                        <strong>Steg 2 av 3</strong> Skriv meddelande.
+                                                    </p>
+                                                    <Button
+                                                        variant="secondary"
+                                                        onClick={() => setActiveTab('step-one')}
+                                                        className="mr-2"
+                                                    >
+                                                        Gå tillbaka
+                                                    </Button>
+                                                    <Button
+                                                        variant="primary"
+                                                        onClick={() => setActiveTab('step-three')}
+                                                        className="mr-2"
+                                                        disabled={message.length === 0}
+                                                    >
+                                                        Gå vidare
+                                                    </Button>
+                                                </div>
+                                            </Card.Body>
+                                        </Card>
 
-                                <Form.Group controlId="formName">
-                                    <Form.Label>Meddelande</Form.Label>
-                                    <Form.Control
-                                        required={true}
-                                        as="textarea"
-                                        name="message"
-                                        rows={6}
-                                        placeholder="En ny månad har börjat och det är dags att klarmarkera bokningar."
-                                        value={message}
-                                        onChange={(e) => setMessage(e.target.value)}
-                                    />
-                                </Form.Group>
+                                        <Form.Group controlId="formName">
+                                            <Form.Label>Meddelande</Form.Label>
+                                            <Form.Control
+                                                required={true}
+                                                as="textarea"
+                                                name="message"
+                                                rows={6}
+                                                placeholder="En ny månad har börjat och det är dags att klarmarkera bokningar."
+                                                value={message}
+                                                onChange={(e) => setMessage(e.target.value)}
+                                            />
+                                        </Form.Group>
+                                    </>
+                                ) : null}
                             </Tab.Pane>
                             <Tab.Pane eventKey="step-three">
-                                <Card className="mb-3">
-                                    <Card.Header className="p-1"></Card.Header>
-                                    <Card.Body>
-                                        <div className="d-flex">
-                                            <p className="text-muted flex-grow-1 mb-0">
-                                                <strong>Steg 3 av 3</strong> Förhandsgranskning.
-                                            </p>
-                                            <Button
-                                                variant="secondary"
-                                                onClick={() => setActiveTab('step-two')}
-                                                className="mr-2"
-                                            >
-                                                Gå tillbaka
-                                            </Button>
-                                            <Button
-                                                variant="primary"
-                                                onClick={() => sendMessageAndClose()}
-                                                className="mr-2"
-                                            >
-                                                <FontAwesomeIcon icon={faEnvelope} className="mr-1" /> Skicka meddelande
-                                            </Button>
-                                        </div>
-                                    </Card.Body>
-                                </Card>
-
-                                <Card className="mb-3">
-                                    <Card.Header>Förhandsgranskning av meddelande</Card.Header>
-                                    <Card.Body>
-                                        <div className="d-flex">
-                                            <div className="p-2">
-                                                <UserIcon user={{ userId: userIdForPreview, isLoggedIn: false }} />
-                                            </div>
-                                            <div className="w-100">
-                                                <p className="mb-0">
-                                                    <strong>Backstage2</strong> {formatTime(now)}
-                                                </p>
-                                                <p>{message}</p>
-                                                <div style={{ borderLeft: '3px solid gray' }} className="pl-2">
-                                                    Angående bokningar:
-                                                    <ul>
-                                                        <li>Exempelbokning 1</li>
-                                                        <li>Exempelbokning 2</li>
-                                                    </ul>
+                                {activeTab === 'step-three' ? (
+                                    <>
+                                        <Card className="mb-3">
+                                            <Card.Header className="p-1"></Card.Header>
+                                            <Card.Body>
+                                                <div className="d-flex">
+                                                    <p className="text-muted flex-grow-1 mb-0">
+                                                        <strong>Steg 3 av 3</strong> Förhandsgranskning.
+                                                    </p>
+                                                    <Button
+                                                        variant="secondary"
+                                                        onClick={() => setActiveTab('step-two')}
+                                                        className="mr-2"
+                                                    >
+                                                        Gå tillbaka
+                                                    </Button>
+                                                    <Button
+                                                        variant="primary"
+                                                        onClick={() => sendMessageAndClose()}
+                                                        className="mr-2"
+                                                    >
+                                                        <FontAwesomeIcon icon={faEnvelope} className="mr-1" /> Skicka
+                                                        meddelande
+                                                    </Button>
                                                 </div>
-                                            </div>
-                                        </div>
-                                    </Card.Body>
-                                </Card>
+                                            </Card.Body>
+                                        </Card>
 
-                                <Card className="mb-3">
-                                    <Card.Header>Mottagare</Card.Header>
-                                    <Card.Body>
-                                        <ul>
-                                            {recipients.map((user) => (
-                                                <li key={user.id}>
-                                                    <p className="mb-0">
-                                                        {user.name}{' '}
-                                                        {!user.slackId ? (
-                                                            <OverlayTrigger
-                                                                placement="right"
-                                                                overlay={
-                                                                    <Tooltip id="1">
-                                                                        <strong>
-                                                                            Denna användare har inget slack-id
-                                                                            konfigurerat och kommer inte att få
-                                                                            meddelandet.
-                                                                        </strong>
-                                                                    </Tooltip>
-                                                                }
-                                                            >
-                                                                <FontAwesomeIcon icon={faWarning} />
-                                                            </OverlayTrigger>
-                                                        ) : null}
-                                                    </p>
-                                                    <p className="mb-0 text-muted">
-                                                        {bookings
-                                                            .filter((x) => x.ownerUser!.id === user.id)
-                                                            .filter((x) => selectedBookingIds.includes(x.id))
-                                                            .map((x) => x.name)
-                                                            .join(', ')}
-                                                    </p>
-                                                </li>
-                                            ))}
-                                        </ul>
-                                    </Card.Body>
-                                </Card>
+                                        <Card className="mb-3">
+                                            <Card.Header>Förhandsgranskning av meddelande</Card.Header>
+                                            <Card.Body>
+                                                <div className="d-flex">
+                                                    <div className="p-2">
+                                                        <UserIcon
+                                                            user={{ userId: userIdForPreview, isLoggedIn: false }}
+                                                        />
+                                                    </div>
+                                                    <div className="w-100">
+                                                        <p className="mb-0">
+                                                            <strong>Backstage2</strong> {formatTime(now)}
+                                                        </p>
+                                                        <p>{message}</p>
+                                                        <div style={{ borderLeft: '3px solid gray' }} className="pl-2">
+                                                            Angående bokningar:
+                                                            <ul>
+                                                                <li>Exempelbokning 1</li>
+                                                                <li>Exempelbokning 2</li>
+                                                            </ul>
+                                                        </div>
+                                                    </div>
+                                                </div>
+                                            </Card.Body>
+                                        </Card>
+
+                                        <Card className="mb-3">
+                                            <Card.Header>Mottagare</Card.Header>
+                                            <Card.Body>
+                                                <ul>
+                                                    {recipients.map((user) => (
+                                                        <li key={user.id}>
+                                                            <p className="mb-0">
+                                                                {user.name}{' '}
+                                                                {!user.slackId ? (
+                                                                    <OverlayTrigger
+                                                                        placement="right"
+                                                                        overlay={
+                                                                            <Tooltip id="1">
+                                                                                <strong>
+                                                                                    Denna användare har inget slack-id
+                                                                                    konfigurerat och kommer inte att få
+                                                                                    meddelandet.
+                                                                                </strong>
+                                                                            </Tooltip>
+                                                                        }
+                                                                    >
+                                                                        <FontAwesomeIcon icon={faWarning} />
+                                                                    </OverlayTrigger>
+                                                                ) : null}
+                                                            </p>
+                                                            <p className="mb-0 text-muted">
+                                                                {bookings
+                                                                    .filter((x) => x.ownerUser!.id === user.id)
+                                                                    .filter((x) => selectedBookingIds.includes(x.id))
+                                                                    .map((x) => x.name)
+                                                                    .join(', ')}
+                                                            </p>
+                                                        </li>
+                                                    ))}
+                                                </ul>
+                                            </Card.Body>
+                                        </Card>
+                                    </>
+                                ) : null}
                             </Tab.Pane>
                         </Tab.Content>
                     </Tab.Container>


### PR DESCRIPTION
Improve performance of "send message to booking owners" by not only rendering each tab once.

The problem was the message update triggering a re-render of the component. This included the first tab, which attempted to format all dates of all past bookings (which is performance-intensive). Previously this list existed in the DOM, but where hidden by CSS - with this update it is not rendered at all, which greatly reduces the computational need. Additionally, the component now used the dates rendered by the parent.

Tested on 1000 booking locally, which worked fine (it turns out it is quite easy to get large testing sets by adding loops in mock.js).

---
Resolves #81 