### PR TITLE
Feature: Packlist in web interface (using swr/polling)

### DIFF
--- a/knex/migrations/20250125000000_equipment-list-entry-is-packed.js
+++ b/knex/migrations/20250125000000_equipment-list-entry-is-packed.js
@@ -1,0 +1,11 @@
+export function up(knex) {
+    return knex.schema.alterTable('EquipmentListEntry', (table) => {
+        table.bool('isPacked').notNullable().defaultTo(0);
+    });
+}
+
+export function down(knex) {
+    return knex.schema.alterTable('EquipmentListEntry', (table) => {
+        table.dropColumn('isPacked');
+    });
+}

--- a/src/components/bookings/equipmentLists/CopyEquipmentListEntriesModal.tsx
+++ b/src/components/bookings/equipmentLists/CopyEquipmentListEntriesModal.tsx
@@ -111,6 +111,7 @@ const CopyEquipmentListEntriesModal: React.FC<Props> = ({ show, onHide, onImport
             pricePerUnit: x.pricePerUnit,
             isHidden: x.isHidden,
             account: x.account,
+            isPacked: false,
         };
 
         if (resetNames && x.equipment) {

--- a/src/components/bookings/equipmentLists/EditEquipmentListEntryModal.tsx
+++ b/src/components/bookings/equipmentLists/EditEquipmentListEntryModal.tsx
@@ -339,6 +339,7 @@ const EditEquipmentListEntryModal: React.FC<Props> = ({
                                     equipmentPrice: equipmentListEntryToEditViewModel.equipmentPrice ?? null,
                                     isHidden: equipmentListEntryToEditViewModel.isHidden ?? false,
                                     account: replaceEmptyStringWithNull(equipmentListEntryToEditViewModel.account),
+                                    isPacked: equipmentListEntryToEditViewModel.isPacked ?? false,
                                 };
 
                                 onSave(entryToSave, !equipmentListEntryToEditViewModel.id);

--- a/src/components/bookings/equipmentLists/EquipmentListHeader.tsx
+++ b/src/components/bookings/equipmentLists/EquipmentListHeader.tsx
@@ -15,6 +15,7 @@ import {
     faRightToBracket,
     faFileDownload,
     faPercent,
+    faListCheck,
 } from '@fortawesome/free-solid-svg-icons';
 import { EquipmentList, EquipmentListEntry, EquipmentListHeading } from '../../../models/interfaces/EquipmentList';
 import { toIntOrUndefined, getRentalStatusName } from '../../../lib/utils';
@@ -39,6 +40,7 @@ import BookingReturnalNoteModal from '../BookingReturnalNoteModal';
 import CopyEquipmentListEntriesModal from './CopyEquipmentListEntriesModal';
 import EditEquipmentListDatesModal from './EditEquipmentListDatesModal';
 import EditTextModal from '../../utils/EditTextModal';
+import Link from 'next/link';
 
 type Props = {
     list: EquipmentList;
@@ -321,11 +323,19 @@ const EquipmentListHeader: React.FC<Props> = ({
                                     </Dropdown.Item>
                                 ) : null}
 
+                                <Dropdown.Divider />
+
+                                <Link href={'/bookings/' + bookingId + '/equipmentList/' + list.id} passHref>
+                                    <Dropdown.Item href={'/bookings/' + bookingId + '/equipmentList/' + list.id}>
+                                        <FontAwesomeIcon icon={faListCheck} className="mr-1 fa-fw" /> Visa som packlista
+                                    </Dropdown.Item>
+                                </Link>
+
                                 <Dropdown.Item
                                     href={'/api/documents/packing-list/sv/' + bookingId + '?list=' + list.id}
                                     target="_blank"
                                 >
-                                    <FontAwesomeIcon icon={faFileDownload} className="mr-1 fa-fw" /> Packlista
+                                    <FontAwesomeIcon icon={faFileDownload} className="mr-1 fa-fw" /> Ladda ner packlista
                                 </Dropdown.Item>
 
                                 <Dropdown.Divider />

--- a/src/lib/equipmentListUtils.ts
+++ b/src/lib/equipmentListUtils.ts
@@ -137,6 +137,7 @@ export const getDefaultListEntryFromEquipment = (
         discount: currency(0),
         isHidden: false,
         account: null,
+        isPacked: false,
         ...prices,
     };
 
@@ -366,6 +367,7 @@ export const importEquipmentEntries = (
             pricePerHour: x.pricePerHour,
             isHidden: x.isHidden,
             account: x.account,
+            isPacked: false,
         };
 
         nextEntryId -= 1;

--- a/src/models/interfaces/EquipmentList.ts
+++ b/src/models/interfaces/EquipmentList.ts
@@ -42,6 +42,7 @@ export interface EquipmentListEntry extends BaseEntityWithName {
     discount: currency;
     isHidden: boolean;
     account: string | null;
+    isPacked: boolean;
 
     equipmentListId?: number | null;
     equipmentListHeadingId?: number | null;

--- a/src/models/objection-models/BookingObjectionModel.ts
+++ b/src/models/objection-models/BookingObjectionModel.ts
@@ -285,6 +285,7 @@ export interface IEquipmentListEntryObjectionModel extends BaseObjectionModelWit
     discount: number;
     isHidden: boolean;
     account: string | null;
+    isPacked: boolean;
 
     equipmentListId?: number | null;
     equipmentListHeadingId?: number | null;
@@ -332,6 +333,7 @@ export class EquipmentListEntryObjectionModel extends Model implements IEquipmen
     discount!: number;
     isHidden!: boolean;
     account!: string | null;
+    isPacked!: boolean;
 
     equipmentListId?: number | null;
     equipmentListHeadingId?: number | null;

--- a/src/pages/bookings/[id]/equipmentList/[listId]/index.tsx
+++ b/src/pages/bookings/[id]/equipmentList/[listId]/index.tsx
@@ -1,0 +1,210 @@
+import React from 'react';
+import useSwr from 'swr';
+import { useRouter } from 'next/router';
+import { TextLoadingPage } from '../../../../../components/layout/LoadingPageSkeleton';
+import { useUserWithDefaultAccessAndWithSettings } from '../../../../../lib/useUser';
+import { KeyValue } from '../../../../../models/interfaces/KeyValue';
+import { CurrentUserInfo } from '../../../../../models/misc/CurrentUserInfo';
+import { ErrorPage } from '../../../../../components/layout/ErrorPage';
+import { bookingFetcher, equipmentListFetcher } from '../../../../../lib/fetchers';
+import { toBookingViewModel } from '../../../../../lib/datetimeUtils';
+import Layout from '../../../../../components/layout/Layout';
+import Header from '../../../../../components/layout/Header';
+import { TableConfiguration, TableDisplay } from '../../../../../components/TableDisplay';
+import { EquipmentListEntry } from '../../../../../models/interfaces/EquipmentList';
+import { Button, Dropdown, DropdownButton } from 'react-bootstrap';
+import Link from 'next/link';
+import { faListCheck } from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { saveListEntryApiCall } from '../../../../../lib/equipmentListUtils';
+import { useNotifications } from '../../../../../lib/useNotifications';
+import { faCheckSquare } from '@fortawesome/free-regular-svg-icons';
+import { Role } from '../../../../../models/enums/Role';
+import { Status } from '../../../../../models/enums/Status';
+
+// eslint-disable-next-line react-hooks/rules-of-hooks
+export const getServerSideProps = useUserWithDefaultAccessAndWithSettings();
+type Props = { user: CurrentUserInfo; globalSettings: KeyValue[] };
+
+const BookingPage: React.FC<Props> = ({ user: currentUser, globalSettings }: Props) => {
+    const { showSaveSuccessNotification, showSaveFailedNotification } = useNotifications();
+
+    const router = useRouter();
+    const { data: bookingData, error: bookingError } = useSwr('/api/bookings/' + router.query.id, bookingFetcher);
+    const {
+        data: list,
+        error: listError,
+        mutate: mutateList,
+    } = useSwr('/api/bookings/' + router.query.id + '/equipmentLists/' + router.query.listId, equipmentListFetcher, {
+        refreshInterval: 10000,
+    });
+
+    if (bookingError || listError) {
+        return (
+            <ErrorPage
+                errorMessage={(bookingError ?? listError).message}
+                fixedWidth={true}
+                currentUser={currentUser}
+                globalSettings={globalSettings}
+            />
+        );
+    }
+
+    if (!bookingData || !list) {
+        return (
+            <TextLoadingPage
+                fixedWidth={true}
+                currentUser={currentUser}
+                globalSettings={globalSettings}
+            ></TextLoadingPage>
+        );
+    }
+
+    const booking = toBookingViewModel(bookingData);
+    const allListEntries = [...list.listEntries, ...list.listHeadings.flatMap((x) => x.listEntries ?? [])];
+    const readonly = currentUser.role === Role.READONLY || booking.status === Status.DONE;
+
+    const saveListEntry = async (isPacked: boolean, listEntryId: number, bookingId: number) => {
+        if (readonly) {
+            return;
+        }
+
+        const entry: Partial<EquipmentListEntry> = {
+            id: listEntryId,
+            isPacked: isPacked,
+        };
+        saveListEntryApiCall(entry, bookingId)
+            .then(() => {
+                showSaveSuccessNotification('Listan');
+                mutateList();
+            })
+            .catch((error: Error) => {
+                console.error(error);
+                showSaveFailedNotification('Listan');
+                mutateList();
+            });
+    };
+
+    const markAllAsPacked = () => {
+        if (readonly) {
+            return;
+        }
+
+        const entries = allListEntries.map((entry) => ({
+            id: entry.id,
+            isPacked: true,
+        }));
+        Promise.all(entries.map(async (entry) => saveListEntryApiCall(entry, booking.id)))
+            .then(() => {
+                showSaveSuccessNotification('Listan');
+                mutateList();
+            })
+            .catch((error: Error) => {
+                console.error(error);
+                showSaveFailedNotification('Listan');
+                mutateList();
+            });
+    };
+
+    // The page itself
+    //
+    const pageTitle = list?.name;
+    const breadcrumbs = [
+        { link: '/bookings', displayName: 'Bokningar' },
+        { link: '/bookings/' + booking.id, displayName: booking.name },
+        { link: '/bookings/' + booking.id, displayName: pageTitle },
+    ];
+
+    const checkmarkDisplayFn = (entry: EquipmentListEntry) => (
+        <div className="text-center">
+            <input
+                type="checkbox"
+                checked={entry.isPacked}
+                disabled={readonly}
+                onChange={() => saveListEntry(!entry.isPacked, entry.id, booking.id)}
+            />
+        </div>
+    );
+
+    const EquipmentEntryNameDisplayFn = (entry: EquipmentListEntry) => (
+        <div onClick={() => saveListEntry(!entry.isPacked, entry.id, booking.id)}>
+            {entry.name}
+            <div className="text-muted mb-0">{entry.description}</div>
+        </div>
+    );
+
+    const tableSettings: TableConfiguration<EquipmentListEntry> = {
+        entityTypeDisplayName: '',
+        defaultSortPropertyName: 'location',
+        defaultSortAscending: true,
+        hideTableFilter: true,
+        hideTableCountControls: true,
+        columns: [
+            {
+                key: 'checkmark',
+                displayName: '',
+                getValue: () => '',
+                getContentOverride: checkmarkDisplayFn,
+                columnWidth: 60,
+                disableSort: true,
+            },
+            {
+                key: 'name',
+                displayName: 'Utrustning',
+                getValue: (entry: EquipmentListEntry) => entry.name + ' ' + entry.description,
+                getHeadingValue: (entry: EquipmentListEntry) => entry.name.charAt(0),
+                getContentOverride: EquipmentEntryNameDisplayFn,
+                disableSort: true,
+            },
+            {
+                key: 'location',
+                displayName: 'Plats',
+                getValue: (entry: EquipmentListEntry) => entry.equipment?.equipmentLocation?.name ?? 'Okänd plats',
+                getHeadingValue: (entry: EquipmentListEntry) =>
+                    entry.equipment?.equipmentLocation?.name ?? 'Okänd plats',
+                cellHideSize: 'xl',
+                columnWidth: 200,
+                disableSort: true,
+            },
+            {
+                key: 'count',
+                displayName: 'Antal',
+                getValue: (entry: EquipmentListEntry) => entry.numberOfUnits ?? '-',
+                getContentOverride: (entry: EquipmentListEntry) =>
+                    entry.numberOfUnits === null ? '-' : entry.numberOfUnits + ' st',
+                getHeadingValue: (entry: EquipmentListEntry) =>
+                    entry.numberOfUnits === null ? '-' : entry.numberOfUnits + ' st',
+                textAlignment: 'center',
+                columnWidth: 120,
+                disableSort: true,
+            },
+        ],
+    };
+
+    return (
+        <Layout title={pageTitle} fixedWidth={true} currentUser={currentUser} globalSettings={globalSettings}>
+            <Header title={pageTitle} breadcrumbs={breadcrumbs}>
+                <Button variant="secondary" onClick={() => markAllAsPacked()} disabled={readonly}>
+                    <FontAwesomeIcon icon={faCheckSquare} className="mr-1" /> Markera alla som packade
+                </Button>
+                <DropdownButton
+                    id="other-lists-dropdown-button"
+                    variant="secondary"
+                    title="Välj lista"
+                    className="d-inline-block"
+                >
+                    {booking.equipmentLists?.map((l) => (
+                        <Link href={`/bookings/${booking.id}/equipmentList/${l.id}`} key={l.id} passHref>
+                            <Dropdown.Item href={`/bookings/${booking.id}/equipmentList/${l.id}`}>
+                                <FontAwesomeIcon icon={faListCheck} className="mr-1 fa-fw" /> {l.name}
+                            </Dropdown.Item>
+                        </Link>
+                    ))}
+                </DropdownButton>
+            </Header>
+            <TableDisplay entities={allListEntries} configuration={{ ...tableSettings }} />
+        </Layout>
+    );
+};
+
+export default BookingPage;


### PR DESCRIPTION
This is a simple implementation of a web-based packing list using the available component/techniques. It uses swr with polling every 10 seconds (while the page is in focus) to keep the information somewhat "live" while multiple people are packing at the same time. It would of course be even better with a websockets-based implementation, but that will take much more effort so I think this is a good start.

The packing-list feature is accessed from the "Mer"-dropdown in the booking view, but it also allows users to switch between multiple lists on the same booking without leaving the packlist interface. These packing list buttons are only available for bookings which are not marked as done, and only users with write-access to stage are allowed to update it. Updates to the packing status of an equipment list entry is not recorded in the booking changelog.

The page is accessed with the url /bookings/[X]/equipmentList/[Y], and can therefore be permalinked/shared/bookmarked if necessary. Note that if you try to access the packing list of a done booking if will be shown in read-only-mode. 


![image](https://github.com/user-attachments/assets/f8e8f5ca-54fe-41df-a613-91351be44afd)

![image](https://github.com/user-attachments/assets/430f58fe-06ae-445c-be28-6f7fc980c2ca)

![image](https://github.com/user-attachments/assets/dd425eb4-8ff5-42c7-b4da-11423dae9337)

![image](https://github.com/user-attachments/assets/693d8dd4-a711-4270-a492-4431d048137e)

---
Resolves #84 