### PR TITLE
Feature: Start DM groups when messaging booking owners

### DIFF
--- a/src/lib/slack.ts
+++ b/src/lib/slack.ts
@@ -35,7 +35,7 @@ export const startDmGroupWithUsers = async (userSlackIds: string[]): Promise<str
     }
 };
 
-export const sendSlackMessageToUserRegardingBookings = async (
+export const sendSlackMessageToUsersRegardingBookings = async (
     message: string,
     bookings: { id: number; name: string }[],
     userSlackIds: string[],

--- a/src/pages/api/sendMessage/toBookingOwners.ts
+++ b/src/pages/api/sendMessage/toBookingOwners.ts
@@ -4,7 +4,7 @@ import { SessionContext, withSessionContext } from '../../../lib/sessionContext'
 import { fetchBookings, fetchUser } from '../../../lib/db-access';
 import { onlyUniqueById } from '../../../lib/utils';
 import { toUser } from '../../../lib/mappers/user';
-import { sendSlackMessageToUserRegardingBookings } from '../../../lib/slack';
+import { sendSlackMessageToUsersRegardingBookings } from '../../../lib/slack';
 import { logMessageSentToBookingOwner } from '../../../lib/changelogUtils';
 
 const handler = withSessionContext(
@@ -43,7 +43,7 @@ const handler = withSessionContext(
                         : [recipient.slackId];
                     const bookingsForRecipient = bookings.filter((x) => x.ownerUser!.id === recipient.id);
 
-                    return sendSlackMessageToUserRegardingBookings(message, bookingsForRecipient, slackIds);
+                    return sendSlackMessageToUsersRegardingBookings(message, bookingsForRecipient, slackIds);
                 }),
             );
 

--- a/src/pages/api/sendMessage/toBookingOwners.ts
+++ b/src/pages/api/sendMessage/toBookingOwners.ts
@@ -1,7 +1,7 @@
 import { NextApiRequest, NextApiResponse } from 'next';
 import { respondWithCustomErrorMessage, respondWithInvalidDataResponse } from '../../../lib/apiResponses';
 import { SessionContext, withSessionContext } from '../../../lib/sessionContext';
-import { fetchBookings } from '../../../lib/db-access';
+import { fetchBookings, fetchUser } from '../../../lib/db-access';
 import { onlyUniqueById } from '../../../lib/utils';
 import { toUser } from '../../../lib/mappers/user';
 import { sendSlackMessageToUserRegardingBookings } from '../../../lib/slack';
@@ -22,7 +22,13 @@ const handler = withSessionContext(
             return;
         }
 
+        if (!context.currentUser.userId) {
+            throw new Error('User not logged in');
+        }
+
         try {
+            const currentUser = await fetchUser(context.currentUser.userId);
+
             const bookings = (await fetchBookings()).filter((x) => bookingIds.includes(x.id));
             const recipients = bookings
                 .map((x) => x.ownerUser!)
@@ -32,10 +38,12 @@ const handler = withSessionContext(
 
             await Promise.all(
                 recipients.map((recipient) => {
-                    const slackId = recipient.slackId;
+                    const slackIds = !!currentUser?.slackId
+                        ? [recipient.slackId, currentUser.slackId]
+                        : [recipient.slackId];
                     const bookingsForRecipient = bookings.filter((x) => x.ownerUser!.id === recipient.id);
 
-                    return sendSlackMessageToUserRegardingBookings(message, bookingsForRecipient, slackId);
+                    return sendSlackMessageToUserRegardingBookings(message, bookingsForRecipient, slackIds);
                 }),
             );
 


### PR DESCRIPTION
Start groups (with the bot, the sender, and the booking owner) instead of only a message between the bot and the owner when sending admin messages from stage. This allows the booking owner to respond to the sender in the same channel, and allows the sender to see what has been sent.

Please note: This requires the [mpim:write](https://api.slack.com/scopes/mpim:write) slack permission in addition to chat:write
![image](https://github.com/user-attachments/assets/3fa9b354-5667-49f7-8a6d-89108e4d43f9)

---

Resolves #88 