### PR TITLE
Feature: Select price on equipment packages

### DIFF
--- a/knex/migrations/20250131000000_package_equipment_price.js
+++ b/knex/migrations/20250131000000_package_equipment_price.js
@@ -1,0 +1,11 @@
+export function up(knex) {
+    return knex.schema.alterTable('EquipmentPackageEntry', (table) => {
+        table.integer('equipmentPriceId');
+    });
+}
+
+export function down(knex) {
+    return knex.schema.alterTable('EquipmentPackageEntry', (table) => {
+        table.dropColumn('equipmentPriceId');
+    });
+}

--- a/src/components/equipmentPackage/PackageEquipmentList.tsx
+++ b/src/components/equipmentPackage/PackageEquipmentList.tsx
@@ -18,10 +18,12 @@ const PackageEquipmentList: React.FC<Props> = ({ equipmentPackage, language = La
                 <ListGroup.Item key={e.id} className="d-flex">
                     <span className="flex-grow-1">
                         {language == Language.SV ? e.equipment?.name : e.equipment?.nameEN}
-                        <br />
-                        <span className="text-muted">
-                            {language == Language.SV ? e.equipment?.description : e.equipment?.descriptionEN}
-                        </span>
+                        {!!(language == Language.SV ? e.equipment?.description : e.equipment?.descriptionEN) ? (
+                            <p className="text-muted  mb-0">
+                                {language == Language.SV ? e.equipment?.description : e.equipment?.descriptionEN}
+                            </p>
+                        ) : null}
+                        {e.equipmentPrice ? <p className="text-muted mb-0">{e.equipmentPrice.name}</p> : null}
                     </span>
                     <span>
                         {e.isHidden ? (

--- a/src/lib/db-access/equipmentPackage.ts
+++ b/src/lib/db-access/equipmentPackage.ts
@@ -43,6 +43,7 @@ export const fetchEquipmentPackage = async (
     return EquipmentPackageObjectionModel.query(trx)
         .findById(id)
         .withGraphFetched('equipmentEntries.equipment.prices')
+        .withGraphFetched('equipmentEntries.equipmentPrice')
         .withGraphFetched('tags');
 };
 
@@ -50,6 +51,7 @@ export const fetchEquipmentPackages = async (): Promise<EquipmentPackageObjectio
     ensureDatabaseIsInitialized();
     return EquipmentPackageObjectionModel.query()
         .withGraphFetched('equipmentEntries.equipment')
+        .withGraphFetched('equipmentEntries.equipmentPrice')
         .withGraphFetched('tags');
 };
 

--- a/src/lib/equipmentListUtils.ts
+++ b/src/lib/equipmentListUtils.ts
@@ -251,9 +251,16 @@ export const addEquipmentPackage = (
         return;
     }
     addMultipleEquipment(
-        getSortedList(equipmentPackage.equipmentEntries).filter((x) => x.equipment) as (EquipmentPackageEntry & {
-            equipment: Equipment;
-        })[],
+        getSortedList(equipmentPackage.equipmentEntries)
+            .filter((x) => x.equipment)
+            .map((x) => ({
+                equipment: x.equipment!,
+                numberOfUnits: x.numberOfUnits,
+                numberOfHours: x.numberOfHours,
+                isFree: x.isFree,
+                isHidden: x.isHidden,
+                selectedPriceId: x.equipmentPriceId ?? undefined,
+            })),
         list,
         pricePlan,
         language,

--- a/src/lib/mappers/equipmentPackage.ts
+++ b/src/lib/mappers/equipmentPackage.ts
@@ -3,7 +3,7 @@ import {
     IEquipmentPackageObjectionModel,
 } from '../../models/objection-models/EquipmentPackageObjectionModel';
 import { EquipmentPackage, EquipmentPackageEntry } from '../../models/interfaces/EquipmentPackage';
-import { toEquipment, toEquipmentTag } from './equipment';
+import { toEquipment, toEquipmentPrice, toEquipmentTag } from './equipment';
 import { toDatetimeOrUndefined } from '../datetimeUtils';
 
 export const toEquipmentPackage = (objectionModel: IEquipmentPackageObjectionModel): EquipmentPackage => {
@@ -35,6 +35,7 @@ export const toEquipmentPackageEntry = (
         ...objectionModel,
         id: objectionModel.id,
         equipment: objectionModel.equipment ? toEquipment(objectionModel.equipment) : undefined,
+        equipmentPrice: objectionModel.equipmentPrice ? toEquipmentPrice(objectionModel.equipmentPrice) : undefined,
         updated: toDatetimeOrUndefined(objectionModel.updated),
         created: toDatetimeOrUndefined(objectionModel.created),
     };

--- a/src/models/interfaces/EquipmentPackage.ts
+++ b/src/models/interfaces/EquipmentPackage.ts
@@ -2,6 +2,7 @@ import { BaseEntity, BaseEntityWithName } from './BaseEntity';
 import { Equipment } from './Equipment';
 import { Image } from './Image';
 import { EquipmentTag } from './EquipmentTag';
+import { EquipmentPrice } from './EquipmentPrice';
 
 export interface EquipmentPackage extends BaseEntityWithName {
     note: string;
@@ -18,6 +19,8 @@ export interface EquipmentPackage extends BaseEntityWithName {
 export interface EquipmentPackageEntry extends BaseEntity {
     equipmentId: number;
     equipment?: Equipment;
+    equipmentPriceId: number | null;
+    equipmentPrice?: EquipmentPrice | null;
     numberOfUnits: number;
     numberOfHours: number;
     sortIndex: number;

--- a/src/models/objection-models/EquipmentPackageObjectionModel.ts
+++ b/src/models/objection-models/EquipmentPackageObjectionModel.ts
@@ -4,6 +4,8 @@ import {
     EquipmentTagObjectionModel,
     IEquipmentTagObjectionModel,
     IEquipmentObjectionModel,
+    EquipmentPriceObjectionModel,
+    IEquipmentPriceObjectionModel,
 } from './EquipmentObjectionModel';
 
 export interface IEquipmentPackageObjectionModel extends BaseObjectionModelWithName {
@@ -70,8 +72,11 @@ export interface IEquipmentPackageEntryObjectionModel extends BaseObjectionModel
     updated?: string;
 
     equipmentId: number;
-
     equipment?: IEquipmentObjectionModel;
+
+    equipmentPriceId: number | null;
+    equipmentPrice?: IEquipmentPriceObjectionModel | null;
+
     numberOfUnits: number;
     numberOfHours: number;
     sortIndex: number;
@@ -91,14 +96,26 @@ export class EquipmentPackageEntryObjectionModel extends Model implements IEquip
                 to: 'Equipment.id',
             },
         },
+        equipmentPrice: {
+            relation: Model.HasOneRelation,
+            modelClass: EquipmentPriceObjectionModel,
+            join: {
+                from: 'EquipmentPackageEntry.equipmentPriceId',
+                to: 'EquipmentPrice.id',
+            },
+        },
     });
 
     id!: number;
     created?: string;
     updated?: string;
-    equipmentId!: number;
 
+    equipmentId!: number;
     equipment?: EquipmentObjectionModel;
+
+    equipmentPriceId!: number | null;
+    equipmentPrice?: EquipmentPriceObjectionModel | null;
+
     numberOfUnits!: number;
     numberOfHours!: number;
     sortIndex!: number;


### PR DESCRIPTION
Add a field for selecting price for each equipment in packages. This allows you to create packages such as "Stagepodiums for use outside", "GrandMA3 Command Wing with Computer", or similar and having the equipment select the appropriate price when used.

To allow for backwards compatability you may also choose no price, which results in the standard default price behavior. If the selected price is deleted, the equipment package entry defaults back to this behavior (aka the property is nullable).

![image](https://github.com/user-attachments/assets/96cf4dc8-8cb3-4eb9-9b81-4d85fd3767fd)
![image](https://github.com/user-attachments/assets/6af86279-c07f-4d4b-8ca9-f11babe40cc8)
![image](https://github.com/user-attachments/assets/4dbd8f7e-506a-41bf-80e6-e8a64ef0ca95)


---
Resolves #92