### PR TITLE
Extend time span for upcoming rentals list

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -353,7 +353,7 @@ export const IsBookingUpcomingRental = (booking: BookingViewModel) => {
         return (
             equipmentOutDatetime &&
             equipmentOutDatetime > addHours(new Date(), -12) &&
-            equipmentOutDatetime < addDays(new Date(), 1)
+            equipmentOutDatetime < addDays(new Date(), 7)
         );
     });
 };

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -66,7 +66,7 @@ const IndexPage: React.FC<Props> = ({ user: currentUser, globalSettings }: Props
                 </Col>
                 <Col xl={6}>
                     <TinyBookingTable
-                        title="Kommande hyror (inom 24h)"
+                        title="Kommande hyror (inom 1 vecka)"
                         bookings={upcomingRentalBookings}
                         showDateHeadings={false}
                     ></TinyBookingTable>


### PR DESCRIPTION
Home screen now shows upcoming rentals for 1 week ahead instead of 24h. Closes #82.