### PR TITLE
Feature: Fetch working users of bookings from calendar

### DIFF
--- a/knex/seeds/mock.js
+++ b/knex/seeds/mock.js
@@ -1971,6 +1971,13 @@ export async function seed(knex) {
             value: '[]',
         },
         {
+            key: 'googleCalendar.nameTagBlackList',
+            note: 'En blacklist som JSON-lista med strängar. Om ett tagg på ett event i kalendern finns med i denna lista visas den inte som en användare uppskriven i kalendern.',
+            created: getVarianceDateString(-100),
+            updated: getVarianceDateString(100),
+            value: '["Många", "Alla", "Internt", "Hyra"]',
+        },
+        {
             key: 'googleCalendar.keywordBlackList',
             note: 'En blacklist som JSON-lista med strängar. Om ett event i kalendern innehåller någon av dessa strängar i namnet visas det inte i listan.',
             created: getVarianceDateString(-100),

--- a/src/components/AddUserAsCoOwnerToAllFutureBookingsForUserButton.tsx
+++ b/src/components/AddUserAsCoOwnerToAllFutureBookingsForUserButton.tsx
@@ -16,7 +16,7 @@ type Props = {
     mutate: () => void;
 };
 
-const ManageCoOwnerBookingsButton: React.FC<Props> = ({
+const AddUserAsCoOwnerToAllFutureBookingsForUserButton: React.FC<Props> = ({
     className,
     currentUser,
     currentCoOwnerBookings,
@@ -92,4 +92,4 @@ const ManageCoOwnerBookingsButton: React.FC<Props> = ({
     );
 };
 
-export default ManageCoOwnerBookingsButton;
+export default AddUserAsCoOwnerToAllFutureBookingsForUserButton;

--- a/src/components/LargeBookingTable.tsx
+++ b/src/components/LargeBookingTable.tsx
@@ -2,7 +2,15 @@ import React, { ChangeEvent } from 'react';
 import { BookingViewModel } from '../models/interfaces';
 import BookingTypeTag from '../components/utils/BookingTypeTag';
 import { TableDisplay, TableConfiguration } from '../components/TableDisplay';
-import { countNullorEmpty, getStatusColor, getStatusName, nameSortFn, notEmpty, onlyUnique, onlyUniqueById } from '../lib/utils';
+import {
+    countNullorEmpty,
+    getStatusColor,
+    getStatusName,
+    nameSortFn,
+    notEmpty,
+    onlyUnique,
+    onlyUniqueById,
+} from '../lib/utils';
 import { Typeahead } from 'react-bootstrap-typeahead';
 import { Col, Form } from 'react-bootstrap';
 import { Status } from '../models/enums/Status';

--- a/src/components/ManageCoOwnerBookingsButton.tsx
+++ b/src/components/ManageCoOwnerBookingsButton.tsx
@@ -53,7 +53,7 @@ const ManageCoOwnerBookingsButton: React.FC<Props> = ({
         const userId = currentUser.userId!;
 
         const calendarEvents = await fetchCalenderEvents();
-        const calenderEventForThisUser = calendarEvents.filter((event) => event.workingUsersIds.includes(userId));
+        const calenderEventForThisUser = calendarEvents.filter((event) => event.workingUsers.map(x => x.id).includes(userId));
         const bookingIds = calenderEventForThisUser.map((event) => event.existingBookingId).filter(notEmpty);
 
         const bookingsToAdd = bookingIds.filter(

--- a/src/components/ManageCoOwnerBookingsButton.tsx
+++ b/src/components/ManageCoOwnerBookingsButton.tsx
@@ -62,6 +62,10 @@ const ManageCoOwnerBookingsButton: React.FC<Props> = ({
         coOwnerBookingsToAdd.forEach((bookingId) => {
             currentUser.userId && bookingId ? addUserAsCoOwnerToBooking(currentUser.userId, bookingId) : null;
         });
+
+        if (coOwnerBookingsToAdd.length === 0) {
+            showGeneralSuccessMessage('Inga nya bokningar att lägga till');
+        }
     };
 
     return (

--- a/src/components/ManageCoOwnerBookingsButton.tsx
+++ b/src/components/ManageCoOwnerBookingsButton.tsx
@@ -35,7 +35,7 @@ const ManageCoOwnerBookingsButton: React.FC<Props> = ({
             headers: { 'Content-Type': 'application/json' },
         };
 
-        fetch('/api/users/' + userId + '/coOwnerBookings/' + bookingId, request)
+        return fetch('/api/users/' + userId + '/coOwnerBookings/' + bookingId, request)
             .then((apiResponse) => getResponseContentOrError<IBookingObjectionModel>(apiResponse))
             .then(() => {
                 showGeneralSuccessMessage('Favorit tillagd');

--- a/src/components/ManageCoOwnerBookingsButton.tsx
+++ b/src/components/ManageCoOwnerBookingsButton.tsx
@@ -1,8 +1,8 @@
-import { faCogs } from '@fortawesome/free-solid-svg-icons';
+import { faCircleNotch, faPlus } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import React from 'react';
 import { Button } from 'react-bootstrap';
-import { getResponseContentOrError } from '../lib/utils';
+import { getResponseContentOrError, notEmpty } from '../lib/utils';
 import { CalendarResult } from '../models/misc/CalendarResult';
 import { CurrentUserInfo } from '../models/misc/CurrentUserInfo';
 import { IBookingObjectionModel } from '../models/objection-models';
@@ -22,13 +22,14 @@ const ManageCoOwnerBookingsButton: React.FC<Props> = ({
     currentCoOwnerBookings,
     mutate,
 }: Props) => {
-    const { showGeneralSuccessMessage, showErrorMessage } = useNotifications();
+    const { showGeneralInfoMessage, showGeneralSuccessMessage, showErrorMessage } = useNotifications();
+    const [isLoading, setIsLoading] = React.useState(false);
 
     const fetchCalenderEvents = async () => {
         return fetch('api/calendar').then((response) => getResponseContentOrError<CalendarResult[]>(response));
     };
 
-    const addUserAsCoOwnerToBooking = async (userId: number, bookingId: number) => {
+    const addUserAsCoOwner = async (userId: number, bookingId: number) => {
         const request = {
             method: 'PUT',
             headers: { 'Content-Type': 'application/json' },
@@ -37,8 +38,7 @@ const ManageCoOwnerBookingsButton: React.FC<Props> = ({
         fetch('/api/users/' + userId + '/coOwnerBookings/' + bookingId, request)
             .then((apiResponse) => getResponseContentOrError<IBookingObjectionModel>(apiResponse))
             .then(() => {
-                showGeneralSuccessMessage('Favoritstatus uppdaterad');
-                mutate();
+                showGeneralSuccessMessage('Favorit tillagd');
             })
             .catch((error: Error) => {
                 console.error(error);
@@ -47,36 +47,44 @@ const ManageCoOwnerBookingsButton: React.FC<Props> = ({
     };
 
     const addUserAsCoOwnerToAllFutureBookingsForUser = async () => {
+        setIsLoading(true);
+        showGeneralInfoMessage('Söker i kalendern efter bokningar...');
+
+        const userId = currentUser.userId!;
+
         const calendarEvents = await fetchCalenderEvents();
+        const calenderEventForThisUser = calendarEvents.filter((event) => event.workingUsersIds.includes(userId));
+        const bookingIds = calenderEventForThisUser.map((event) => event.existingBookingId).filter(notEmpty);
 
-        const calenderEventForThisUser = calendarEvents.filter(
-            (event) => currentUser.userId && event.workingUsersIds.includes(currentUser.userId),
-        );
-
-        const existingBookingIds = calenderEventForThisUser.map((event) => event.existingBookingId);
-
-        const coOwnerBookingsToAdd = existingBookingIds.filter(
+        const bookingsToAdd = bookingIds.filter(
             (bookingId) => !currentCoOwnerBookings.some((booking) => booking.id === bookingId),
         );
 
-        coOwnerBookingsToAdd.forEach((bookingId) => {
-            currentUser.userId && bookingId ? addUserAsCoOwnerToBooking(currentUser.userId, bookingId) : null;
-        });
-
-        if (coOwnerBookingsToAdd.length === 0) {
+        if (bookingsToAdd.length > 0) {
+            await Promise.all(bookingsToAdd.map((bookingId) => addUserAsCoOwner(userId, bookingId)));
+            mutate();
+        } else {
             showGeneralSuccessMessage('Inga nya bokningar att lägga till');
         }
+
+        setIsLoading(false);
     };
 
     return (
         <>
             <Button
                 variant="secondary"
+                size="sm"
+                disabled={isLoading}
                 className={className}
                 onClick={() => addUserAsCoOwnerToAllFutureBookingsForUser()}
             >
-                <FontAwesomeIcon icon={faCogs} className="mr-1" /> Lägg till alla framtida bokningar jag arbetar på som
-                favoriter
+                {isLoading ? (
+                    <FontAwesomeIcon icon={faCircleNotch} className="mr-1" spin />
+                ) : (
+                    <FontAwesomeIcon icon={faPlus} className="mr-1" />
+                )}
+                Favoritmarkera bokningar jag arbetar på
             </Button>
         </>
     );

--- a/src/components/ManageCoOwnerBookingsButton.tsx
+++ b/src/components/ManageCoOwnerBookingsButton.tsx
@@ -53,7 +53,9 @@ const ManageCoOwnerBookingsButton: React.FC<Props> = ({
         const userId = currentUser.userId!;
 
         const calendarEvents = await fetchCalenderEvents();
-        const calenderEventForThisUser = calendarEvents.filter((event) => event.workingUsers.map(x => x.id).includes(userId));
+        const calenderEventForThisUser = calendarEvents.filter((event) =>
+            event.workingUsers.map((x) => x.id).includes(userId),
+        );
         const bookingIds = calenderEventForThisUser.map((event) => event.existingBookingId).filter(notEmpty);
 
         const bookingsToAdd = bookingIds.filter(

--- a/src/components/ManageCoOwnerBookingsButton.tsx
+++ b/src/components/ManageCoOwnerBookingsButton.tsx
@@ -1,0 +1,81 @@
+import { faCogs } from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import React from 'react';
+import { Button } from 'react-bootstrap';
+import { getResponseContentOrError } from '../lib/utils';
+import { CalendarResult } from '../models/misc/CalendarResult';
+import { CurrentUserInfo } from '../models/misc/CurrentUserInfo';
+import { IBookingObjectionModel } from '../models/objection-models';
+import { useNotifications } from '../lib/useNotifications';
+import { Booking } from '../models/interfaces';
+
+type Props = {
+    className?: string;
+    currentUser: CurrentUserInfo;
+    currentCoOwnerBookings: Booking[];
+    mutate: () => void;
+};
+
+const ManageCoOwnerBookingsButton: React.FC<Props> = ({
+    className,
+    currentUser,
+    currentCoOwnerBookings,
+    mutate,
+}: Props) => {
+    const { showGeneralSuccessMessage, showErrorMessage } = useNotifications();
+
+    const fetchCalenderEvents = async () => {
+        return fetch('api/calendar').then((response) => getResponseContentOrError<CalendarResult[]>(response));
+    };
+
+    const addUserAsCoOwnerToBooking = async (userId: number, bookingId: number) => {
+        const request = {
+            method: 'PUT',
+            headers: { 'Content-Type': 'application/json' },
+        };
+
+        fetch('/api/users/' + userId + '/coOwnerBookings/' + bookingId, request)
+            .then((apiResponse) => getResponseContentOrError<IBookingObjectionModel>(apiResponse))
+            .then(() => {
+                showGeneralSuccessMessage('Favoritstatus uppdaterad');
+                mutate();
+            })
+            .catch((error: Error) => {
+                console.error(error);
+                showErrorMessage('Favoritstatus kunde inte uppdateras');
+            });
+    };
+
+    const addUserAsCoOwnerToAllFutureBookingsForUser = async () => {
+        const calendarEvents = await fetchCalenderEvents();
+
+        const calenderEventForThisUser = calendarEvents.filter(
+            (event) => currentUser.userId && event.workingUsersIds.includes(currentUser.userId),
+        );
+
+        const existingBookingIds = calenderEventForThisUser.map((event) => event.existingBookingId);
+
+        const coOwnerBookingsToAdd = existingBookingIds.filter(
+            (bookingId) => !currentCoOwnerBookings.some((booking) => booking.id === bookingId),
+        );
+
+        coOwnerBookingsToAdd.forEach((bookingId) => {
+            currentUser.userId && bookingId ? addUserAsCoOwnerToBooking(currentUser.userId, bookingId) : null;
+        });
+    };
+
+    return (
+        <>
+            <Button
+                variant="secondary"
+                className={className}
+                onClick={() => addUserAsCoOwnerToAllFutureBookingsForUser()}
+            >
+                <FontAwesomeIcon icon={faCogs} className="mr-1" /> Lägg till alla framtida bokningar jag arbetar på som
+                favoriter
+            </Button>
+        </>
+    );
+};
+
+export default ManageCoOwnerBookingsButton;

--- a/src/components/TinyBookingTable.tsx
+++ b/src/components/TinyBookingTable.tsx
@@ -86,12 +86,16 @@ const TinyBookingTable: React.FC<Props> = ({
 
     return (
         <Card className="mb-3">
-            <Card.Header>{title}</Card.Header>
+            <Card.Header>
+                <div className="d-flex justify-content-between">
+                    {title}
+                    {children}
+                </div>
+            </Card.Header>
             <TableDisplay
                 entities={bookings.map(toBookingViewModel)}
                 configuration={{ ...tableSettings, ...tableSettingsOverride }}
             />
-            {children}
         </Card>
     );
 };

--- a/src/components/bookings/CalendarWorkersCard.tsx
+++ b/src/components/bookings/CalendarWorkersCard.tsx
@@ -132,7 +132,7 @@ const CalendarWorkersCardWithCalendarConnection: React.FC<FilesCardListProps> = 
                 </Button>
                 {!readonly ? (
                     <DropdownButton id="dropdown-basic-button" variant="secondary" title="Mer" size="sm">
-                        {!readonly ? (
+                        {!readonly && workingUsers.length > 0 ? (
                             <>
                                 <Dropdown.Item onClick={() => sendMessageToCalendarWorkers(false)}>
                                     <FontAwesomeIcon icon={faMessage} className="mr-1 fa-fw" /> Skicka direktmeddelande

--- a/src/components/bookings/CalendarWorkersCard.tsx
+++ b/src/components/bookings/CalendarWorkersCard.tsx
@@ -1,0 +1,194 @@
+import React, { useState } from 'react';
+import { Button, Card, Dropdown, DropdownButton, ListGroup } from 'react-bootstrap';
+import useSwr from 'swr';
+import { getMemberStatusName, getResponseContentOrError } from '../../lib/utils';
+import {
+    faAngleDown,
+    faAngleUp,
+    faExclamationCircle,
+    faExternalLinkAlt,
+    faHashtag,
+    faMessage,
+    faQuestion,
+    faUser,
+} from '@fortawesome/free-solid-svg-icons';
+import { faUser as faUserRegular } from '@fortawesome/free-regular-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import TableStyleLink from '../utils/TableStyleLink';
+import Skeleton from 'react-loading-skeleton';
+import { CalendarResult } from '../../models/misc/CalendarResult';
+import { MemberStatus } from '../../models/enums/MemberStatus';
+import { useNotifications } from '../../lib/useNotifications';
+
+type Props = {
+    bookingId: number;
+    calendarEventId: string;
+    readonly?: boolean;
+};
+
+const CalendarWorkersCard: React.FC<Props> = ({ bookingId, calendarEventId, readonly = false }: Props) => {
+    // No connection to calendar event
+    //
+    if (calendarEventId === null || calendarEventId === '') {
+        return (
+            <>
+                <Card className="mb-3">
+                    <Card.Header className="d-flex">
+                        <span className="flex-grow-1">Uppskrivna i kalendern</span>
+                    </Card.Header>
+                    <ListGroup variant="flush">
+                        <ListGroup.Item className="text-center font-italic text-muted">
+                            Koppla bokningen till ett kalenderevent för att se uppskrivna arbetare.
+                        </ListGroup.Item>
+                    </ListGroup>
+                </Card>
+            </>
+        );
+    }
+    // Workers list
+    //
+    return (
+        <>
+            <Card className="mb-3">
+                <CalendarWorkersCardWithCalendarConnection
+                    bookingId={bookingId}
+                    calendarEventId={calendarEventId}
+                    readonly={readonly}
+                />
+            </Card>
+        </>
+    );
+};
+
+type FilesCardListProps = {
+    bookingId: number;
+    calendarEventId: string;
+    readonly: boolean;
+};
+
+const CalendarWorkersCardWithCalendarConnection: React.FC<FilesCardListProps> = ({
+    bookingId,
+    calendarEventId,
+    readonly,
+}: FilesCardListProps) => {
+    const [showContent, setShowContent] = useState(true);
+
+    const { data, error } = useSwr(`/api/calendar/${calendarEventId}`, (url) =>
+        fetch(url).then((response) => getResponseContentOrError<CalendarResult>(response)),
+    );
+
+    const { showGeneralSuccessMessage, showGeneralDangerMessage } = useNotifications();
+
+    // Error handling
+    //
+    if (error) {
+        return (
+            <div className="p-3">
+                <p className="text-danger">
+                    <FontAwesomeIcon icon={faExclamationCircle} /> Det gick inte att ladda kalenderevent.
+                </p>
+                <p className="text-monospace text-muted mb-0">{error.message}</p>
+            </div>
+        );
+    }
+
+    // Loading skeleton
+    //
+    if (!data) {
+        return <Skeleton height={150} className="mb-3" />;
+    }
+
+    const workingUsers = data.workingUsers;
+
+    // Send message to booking workers
+    //
+    const sendMessageToCalendarWorkers = (startSlackChannel: boolean) => {
+        const request = {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+                bookingId: bookingId,
+                startSlackChannel: startSlackChannel,
+            }),
+        };
+
+        fetch('/api/sendMessage/toBookingWorkers', request)
+            .then(getResponseContentOrError)
+            .then(() => showGeneralSuccessMessage('Meddelandet skickades'))
+            .catch((error) => {
+                console.error(error);
+                showGeneralDangerMessage('Fel!', 'Meddelandet kunde inte skickas');
+            });
+    };
+
+    // Files list
+    //
+    return (
+        <>
+            <Card.Header className="d-flex">
+                <span className="flex-grow-1">Uppskrivna i kalendern</span>
+                <Button className="mr-2" variant="" size="sm" onClick={() => setShowContent((x) => !x)}>
+                    <FontAwesomeIcon icon={showContent ? faAngleUp : faAngleDown} />
+                </Button>
+                {!readonly ? (
+                    <DropdownButton id="dropdown-basic-button" variant="secondary" title="Mer" size="sm">
+                        {!readonly ? (
+                            <>
+                                <Dropdown.Item onClick={() => sendMessageToCalendarWorkers(false)}>
+                                    <FontAwesomeIcon icon={faMessage} className="mr-1 fa-fw" /> Skicka direktmeddelande
+                                    till de som jobbar
+                                </Dropdown.Item>
+                                <Dropdown.Item onClick={() => sendMessageToCalendarWorkers(true)}>
+                                    <FontAwesomeIcon icon={faHashtag} className="mr-1 fa-fw" /> Skapa slackkanal med de
+                                    som jobbar
+                                </Dropdown.Item>
+                                <Dropdown.Divider />
+                            </>
+                        ) : null}
+                        <Dropdown.Item href={data?.link} target="_blank">
+                            <FontAwesomeIcon icon={faExternalLinkAlt} className="mr-1 fa-fw" /> Öppna i Google Calendar
+                        </Dropdown.Item>
+                    </DropdownButton>
+                ) : null}
+            </Card.Header>
+            {showContent ? (
+                <ListGroup variant="flush">
+                    {workingUsers.map((user) => (
+                        <ListGroup.Item key={user.id}>
+                            <div className="mb-1">
+                                <FontAwesomeIcon icon={getIcon(user.memberStatus)} className="mr-2" />
+                                {user.name !== undefined ? (
+                                    <TableStyleLink href={`/users/${user.id}`}>{user.name}</TableStyleLink>
+                                ) : (
+                                    user.nameTag
+                                )}
+                            </div>
+                            <div className="text-muted">
+                                {user.nameTag}{' '}
+                                {user.memberStatus !== undefined ? `/ ${getMemberStatusName(user.memberStatus)}` : null}
+                            </div>
+                        </ListGroup.Item>
+                    ))}
+                    {workingUsers.length === 0 ? (
+                        <ListGroup.Item className="text-center font-italic text-muted">
+                            Tagga användare i kalendern för att visa dem här.
+                        </ListGroup.Item>
+                    ) : null}
+                </ListGroup>
+            ) : null}
+        </>
+    );
+};
+
+const getIcon = (memberStatus: MemberStatus | undefined) => {
+    switch (memberStatus) {
+        case MemberStatus.ASP:
+            return faUserRegular;
+        case undefined:
+            return faQuestion;
+        default:
+            return faUser;
+    }
+};
+
+export default CalendarWorkersCard;

--- a/src/components/bookings/FilesCard.tsx
+++ b/src/components/bookings/FilesCard.tsx
@@ -23,6 +23,7 @@ import { getSortedList } from '../../lib/sortIndexUtils';
 import TableStyleLink from '../utils/TableStyleLink';
 import Skeleton from 'react-loading-skeleton';
 import { useNotifications } from '../../lib/useNotifications';
+import { getDriveLink } from '../../lib/db-access/utils';
 
 type Props = {
     driveFolderId: string;
@@ -42,7 +43,7 @@ const FilesCard: React.FC<Props> = ({
     const [showContent, setShowContent] = useState(true);
     const { showErrorMessage } = useNotifications();
 
-    const link = 'https://drive.google.com/drive/folders/' + driveFolderId;
+    const link = getDriveLink(driveFolderId);
 
     const createFolder = async (name: string, parentName: string) => {
         const body = {

--- a/src/lib/calenderUtils.ts
+++ b/src/lib/calenderUtils.ts
@@ -36,7 +36,6 @@ export const mapCalendarEvent = async (event: calendar_v3.Schema$Event): Promise
         start: event.start?.dateTime ?? event.start?.date ?? undefined,
         end: event.end?.dateTime ?? event.start?.date ?? undefined,
         existingBookingId: (await fetchFirstBookingByCalendarBookingId(event.id as string))?.id,
-        initials: getNameTagsFromEventName(event.summary ?? ''),
         workingUsers: await getUsersFromEventName(event.summary ?? ''),
     };
 };

--- a/src/lib/calenderUtils.ts
+++ b/src/lib/calenderUtils.ts
@@ -1,12 +1,13 @@
 import { calendar, calendar_v3 } from '@googleapis/calendar';
 import { fetchUserByNameTag } from './db-access/user';
-import { notEmpty } from './utils';
 import { CalendarResult } from '../models/misc/CalendarResult';
 import { fetchFirstBookingByCalendarBookingId } from './db-access/booking';
 import { GaxiosResponse } from 'googleapis-common';
 import { UserObjectionModel } from '../models/objection-models';
+import { getGlobalSetting } from './utils';
+import { fetchSettings } from './db-access/setting';
 
-export const getNameTagsFromEventName = (name: string): string[] => {
+const getNameTagsFromEventName = (name: string): string[] => {
     // Get part of string within [] brackets
     const match = name.match(/\[(.*?)\]/);
     if (match) {
@@ -18,14 +19,30 @@ export const getNameTagsFromEventName = (name: string): string[] => {
     return [];
 };
 
-export const getUsersFromEventName = async (name: string): Promise<UserObjectionModel[]> => {
-    const nameTags = getNameTagsFromEventName(name ?? '');
-    const users = await Promise.all(nameTags.map(fetchUserByNameTag));
+const getUserByTag = async (tag: string): Promise<Partial<UserObjectionModel>> => {
+    const user = await fetchUserByNameTag(tag);
 
-    return users.filter(notEmpty);
+    if (!user) {
+        return { nameTag: tag };
+    }
+
+    return user;
 };
 
-export const mapCalendarEvent = async (event: calendar_v3.Schema$Event): Promise<CalendarResult> => {
+const getUsersFromEventName = async (
+    name: string,
+    nameTagBlackList: string[],
+): Promise<Partial<UserObjectionModel>[]> => {
+    const nameTags = getNameTagsFromEventName(name ?? '');
+    const users = await Promise.all(nameTags.map(getUserByTag));
+
+    return users.filter((x) => !nameTagBlackList.includes(x.nameTag ?? ''));
+};
+
+const mapCalendarEvent = async (
+    event: calendar_v3.Schema$Event,
+    nameTagBlackList: string[],
+): Promise<CalendarResult> => {
     return {
         id: event.id as string,
         name: event.summary ?? undefined,
@@ -36,16 +53,27 @@ export const mapCalendarEvent = async (event: calendar_v3.Schema$Event): Promise
         start: event.start?.dateTime ?? event.start?.date ?? undefined,
         end: event.end?.dateTime ?? event.start?.date ?? undefined,
         existingBookingId: (await fetchFirstBookingByCalendarBookingId(event.id as string))?.id,
-        workingUsers: await getUsersFromEventName(event.summary ?? ''),
+        workingUsers: await getUsersFromEventName(event.summary ?? '', nameTagBlackList),
     };
 };
 
-const mapCalendarResponse = (res: GaxiosResponse<calendar_v3.Schema$Events>): Promise<CalendarResult[] | null> => {
+const mapCalendarResponse = (
+    res: GaxiosResponse<calendar_v3.Schema$Events>,
+    nameTagBlackList: string[],
+): Promise<CalendarResult[] | null> => {
     if (!res.data.items) {
         return Promise.resolve(null);
     }
 
-    return Promise.all(res.data.items.filter((x) => x.id).map(mapCalendarEvent));
+    return Promise.all(res.data.items.filter((x) => x.id).map((x) => mapCalendarEvent(x, nameTagBlackList)));
+};
+
+const getNameTagBlacklist = async () => {
+    const globalSettings = await fetchSettings();
+    const nameTagBlackList: string[] = JSON.parse(
+        getGlobalSetting('googleCalendar.nameTagBlackList', globalSettings, '[]'),
+    );
+    return nameTagBlackList;
 };
 
 const calendarClient = calendar({
@@ -53,16 +81,21 @@ const calendarClient = calendar({
     auth: process.env.CALENDAR_API_KEY,
 });
 
-export const getCalendarEvent = (calendarEventId: string) =>
-    calendarClient.events
+export const getCalendarEvent = async (calendarEventId: string) => {
+    const nameTagBlackList: string[] = await getNameTagBlacklist();
+
+    return calendarClient.events
         .get({
             calendarId: process.env.CALENDAR_ID,
             eventId: calendarEventId,
         })
-        .then((result) => mapCalendarEvent(result.data));
+        .then((result) => mapCalendarEvent(result.data, nameTagBlackList));
+};
 
-export const getCalendarEvents = () =>
-    calendarClient.events
+export const getCalendarEvents = async () => {
+    const nameTagBlackList: string[] = await getNameTagBlacklist();
+
+    return calendarClient.events
         .list({
             calendarId: process.env.CALENDAR_ID,
             timeMin: new Date().toISOString(),
@@ -70,4 +103,5 @@ export const getCalendarEvents = () =>
             singleEvents: true,
             orderBy: 'startTime',
         })
-        .then(mapCalendarResponse);
+        .then((x) => mapCalendarResponse(x, nameTagBlackList));
+};

--- a/src/lib/calenderUtils.ts
+++ b/src/lib/calenderUtils.ts
@@ -1,5 +1,5 @@
-import { fetchUserIdByNameTag } from "./db-access/user";
-import { notEmpty } from "./utils";
+import { fetchUserIdByNameTag } from './db-access/user';
+import { notEmpty } from './utils';
 
 export const getNameTagsFromEventName = (name: string): string[] => {
     // Get part of string within [] brackets
@@ -17,5 +17,5 @@ export const getUsersIdsFromEventName = async (name: string): Promise<number[]> 
     const nameTags = getNameTagsFromEventName(name ?? '');
     const users = await Promise.all(nameTags.map(fetchUserIdByNameTag));
 
-    return users.map(x => x?.id).filter(notEmpty);
+    return users.map((x) => x?.id).filter(notEmpty);
 };

--- a/src/lib/calenderUtils.ts
+++ b/src/lib/calenderUtils.ts
@@ -1,0 +1,21 @@
+import { fetchUserIdByNameTag } from "./db-access/user";
+import { notEmpty } from "./utils";
+
+export const getNameTagsFromEventName = (name: string): string[] => {
+    // Get part of string within [] brackets
+    const match = name.match(/\[(.*?)\]/);
+    if (match) {
+        return match[1]
+            .split(',')
+            .map((x) => (x.includes(':') ? x.split(':')[1] : x))
+            .map((x) => x.trim());
+    }
+    return [];
+};
+
+export const getUsersIdsFromEventName = async (name: string): Promise<number[]> => {
+    const nameTags = getNameTagsFromEventName(name ?? '');
+    const users = await Promise.all(nameTags.map(fetchUserIdByNameTag));
+
+    return users.map(x => x?.id).filter(notEmpty);
+};

--- a/src/lib/db-access/user.ts
+++ b/src/lib/db-access/user.ts
@@ -42,12 +42,12 @@ export const fetchUser = async (
     return query;
 };
 
-export const fetchUserIdByNameTag = async (nameTag: string): Promise<UserObjectionModel | undefined> => {
+export const fetchUserByNameTag = async (nameTag: string): Promise<UserObjectionModel | undefined> => {
     ensureDatabaseIsInitialized();
 
     const query = UserObjectionModel.query().findOne('nameTag', '=', nameTag);
 
-    return query.select('id');
+    return query;
 };
 
 export const fetchUserByNameTagForExternalApi = async (nameTag: string): Promise<UserObjectionModel | undefined> => {

--- a/src/lib/db-access/user.ts
+++ b/src/lib/db-access/user.ts
@@ -45,7 +45,19 @@ export const fetchUser = async (
 export const fetchUserByNameTag = async (nameTag: string): Promise<UserObjectionModel | undefined> => {
     ensureDatabaseIsInitialized();
 
-    const query = UserObjectionModel.query().findOne('nameTag', '=', nameTag);
+    const query = UserObjectionModel.query()
+        .findOne('nameTag', '=', nameTag)
+        .select(
+            'id',
+            'name',
+            'created',
+            'updated',
+            'memberStatus',
+            'nameTag',
+            'phoneNumber',
+            'slackId',
+            'emailAddress',
+        );
 
     return query;
 };

--- a/src/lib/db-access/user.ts
+++ b/src/lib/db-access/user.ts
@@ -42,6 +42,14 @@ export const fetchUser = async (
     return query;
 };
 
+export const fetchUserIdByNameTag = async (nameTag: string): Promise<UserObjectionModel | undefined> => {
+    ensureDatabaseIsInitialized();
+
+    const query = UserObjectionModel.query().findOne('nameTag', '=', nameTag);
+
+    return query.select('id');
+};
+
 export const fetchUserByNameTagForExternalApi = async (nameTag: string): Promise<UserObjectionModel | undefined> => {
     ensureDatabaseIsInitialized();
 

--- a/src/lib/db-access/utils.ts
+++ b/src/lib/db-access/utils.ts
@@ -32,3 +32,5 @@ export const compareLists = <T extends BaseObjectionModel>(
 
     return { toAdd, toDelete, toUpdate };
 };
+
+export const getDriveLink = (driveFolderId: string) => 'https://drive.google.com/drive/folders/' + driveFolderId;

--- a/src/lib/slack.ts
+++ b/src/lib/slack.ts
@@ -193,16 +193,18 @@ export const sendMessageToUsersForBooking = async (
     const uniqueUserSlackIds = userSlackIds.filter(onlyUnique);
     const bookingViewModel = toBookingViewModel(booking);
 
-    let formattedMessage = `Denna kanal har automatiskt skapats för bokningen *${booking.name}* som äger rum ${bookingViewModel.displayUsageInterval}. Här kan ni diskutera bokningen och dela viktig information.\n\nLänkar:\n- <${process.env.APPLICATION_BASE_URL}/bookings/${booking.id}|Backstage2-bokning>`;
+    let formattedMessage = `*${booking.name}*\n${bookingViewModel.displayUsageInterval}\nDenna ${startSlackChannel ? "kanal" : "grupp"} har skapats av Backstage2. Här kan ni diskutera bokningen och dela viktig information.\n\nBokningslänkar:\n<${process.env.APPLICATION_BASE_URL}/bookings/${booking.id}|:better-rn: Backstage2-bokning>`;
 
     if (booking.driveFolderId) {
         const driveLink = await getDriveLink(booking.driveFolderId);
-        formattedMessage += `\n- <${driveLink}|Google Drive>`;
+        formattedMessage += `\n<${driveLink}|:google-drive: Google Drive-mapp>`;
     }
 
     if (calendarLink) {
-        formattedMessage += `\n- <${calendarLink}|Google Calendar>`;
+        formattedMessage += `\n<${calendarLink}|:calendar: Google Calendar-event>`;
     }
+
+    formattedMessage += "\n\nHa ett trevligt gigg! :dancing_penguin:"
 
     if (startSlackChannel) {
         const channelName = getChannelNameForBooking(bookingViewModel);

--- a/src/lib/slack.ts
+++ b/src/lib/slack.ts
@@ -191,7 +191,6 @@ export const startSlackChannelWithUsersForBooking = async (booking: Booking, use
     const channelId = await startChannelIfNotExists(channelName);
 
     await inviteUsersToChannel(uniqueUserSlackIds, channelId);
-
     await sendSlackMessage(formattedMessage, channelId);
 };
 

--- a/src/models/misc/CalendarResult.ts
+++ b/src/models/misc/CalendarResult.ts
@@ -10,5 +10,5 @@ export interface CalendarResult {
     start?: string;
     end?: string;
     existingBookingId?: number;
-    workingUsers: UserObjectionModel[];
+    workingUsers: Partial<UserObjectionModel>[];
 }

--- a/src/models/misc/CalendarResult.ts
+++ b/src/models/misc/CalendarResult.ts
@@ -10,6 +10,5 @@ export interface CalendarResult {
     start?: string;
     end?: string;
     existingBookingId?: number;
-    initials: string[];
     workingUsers: UserObjectionModel[];
 }

--- a/src/models/misc/CalendarResult.ts
+++ b/src/models/misc/CalendarResult.ts
@@ -8,4 +8,6 @@ export interface CalendarResult {
     start?: string;
     end?: string;
     existingBookingId?: number;
+    initials: string[];
+    workingUsersIds: number[];
 }

--- a/src/models/misc/CalendarResult.ts
+++ b/src/models/misc/CalendarResult.ts
@@ -1,3 +1,5 @@
+import { UserObjectionModel } from '../objection-models';
+
 export interface CalendarResult {
     id: string;
     name?: string;
@@ -9,5 +11,5 @@ export interface CalendarResult {
     end?: string;
     existingBookingId?: number;
     initials: string[];
-    workingUsersIds: number[];
+    workingUsers: UserObjectionModel[];
 }

--- a/src/pages/api/bookings/[bookingId]/equipmentListEntry/[equipmentListEntryId].ts
+++ b/src/pages/api/bookings/[bookingId]/equipmentListEntry/[equipmentListEntryId].ts
@@ -82,7 +82,6 @@ const handler = withSessionContext(
 
                 await updateEquipmentListEntry(equipmentListEntryId, req.body.equipmentListEntry)
                     .then(async (result) => {
-
                         if (hasChanges(oldEquipmentListEntry, req.body.equipmentListEntry, ['isPacked'])) {
                             await logChangeToBooking(
                                 context.currentUser,

--- a/src/pages/api/calendar/[id].ts
+++ b/src/pages/api/calendar/[id].ts
@@ -1,0 +1,43 @@
+import { calendar } from '@googleapis/calendar';
+import { NextApiRequest, NextApiResponse } from 'next';
+import {
+    respondWithCustomErrorMessage,
+    respondWithEntityNotFoundResponse,
+    respondWithInvalidMethodResponse,
+} from '../../../lib/apiResponses';
+import { withSessionContext } from '../../../lib/sessionContext';
+import { mapCalendarEvent } from '../../../lib/calenderUtils';
+
+const calendarClient = calendar({
+    version: 'v3',
+    auth: process.env.CALENDAR_API_KEY,
+});
+
+const handler = withSessionContext(async (req: NextApiRequest, res: NextApiResponse): Promise<void> => {
+    const calendarEventId = req.query.id;
+
+    if (!calendarEventId) {
+        respondWithEntityNotFoundResponse(res);
+        return;
+    }
+
+    switch (req.method) {
+        case 'GET':
+            await calendarClient.events
+                .get({
+                    calendarId: process.env.CALENDAR_ID,
+                    eventId: calendarEventId.toString(),
+                })
+                .then((result) => mapCalendarEvent(result.data))
+                .then((result) => res.status(200).json(result))
+                .catch((error) => respondWithCustomErrorMessage(res, error.message));
+
+            break;
+
+        default:
+            respondWithInvalidMethodResponse(res);
+    }
+    return;
+});
+
+export default handler;

--- a/src/pages/api/calendar/[id].ts
+++ b/src/pages/api/calendar/[id].ts
@@ -1,4 +1,3 @@
-import { calendar } from '@googleapis/calendar';
 import { NextApiRequest, NextApiResponse } from 'next';
 import {
     respondWithCustomErrorMessage,
@@ -6,12 +5,7 @@ import {
     respondWithInvalidMethodResponse,
 } from '../../../lib/apiResponses';
 import { withSessionContext } from '../../../lib/sessionContext';
-import { mapCalendarEvent } from '../../../lib/calenderUtils';
-
-const calendarClient = calendar({
-    version: 'v3',
-    auth: process.env.CALENDAR_API_KEY,
-});
+import { getCalendarEvent } from '../../../lib/calenderUtils';
 
 const handler = withSessionContext(async (req: NextApiRequest, res: NextApiResponse): Promise<void> => {
     const calendarEventId = req.query.id;
@@ -23,12 +17,7 @@ const handler = withSessionContext(async (req: NextApiRequest, res: NextApiRespo
 
     switch (req.method) {
         case 'GET':
-            await calendarClient.events
-                .get({
-                    calendarId: process.env.CALENDAR_ID,
-                    eventId: calendarEventId.toString(),
-                })
-                .then((result) => mapCalendarEvent(result.data))
+            await getCalendarEvent(calendarEventId.toString())
                 .then((result) => res.status(200).json(result))
                 .catch((error) => respondWithCustomErrorMessage(res, error.message));
 

--- a/src/pages/api/calendar/index.ts
+++ b/src/pages/api/calendar/index.ts
@@ -1,17 +1,10 @@
-import { calendar_v3, calendar } from '@googleapis/calendar';
-import { GaxiosResponse } from 'googleapis-common';
 import { NextApiRequest, NextApiResponse } from 'next';
 import { respondWithCustomErrorMessage, respondWithInvalidMethodResponse } from '../../../lib/apiResponses';
 import { fetchSettings } from '../../../lib/db-access/setting';
 import { withSessionContext } from '../../../lib/sessionContext';
 import { getGlobalSetting } from '../../../lib/utils';
 import { CalendarResult } from '../../../models/misc/CalendarResult';
-import { mapCalendarEvent } from '../../../lib/calenderUtils';
-
-const calendarClient = calendar({
-    version: 'v3',
-    auth: process.env.CALENDAR_API_KEY,
-});
+import { getCalendarEvents } from '../../../lib/calenderUtils';
 
 const filterCalendarEvents = async (events: CalendarResult[] | null) => {
     if (!events) {
@@ -38,26 +31,10 @@ const filterCalendarEvents = async (events: CalendarResult[] | null) => {
     return events.filter(filter);
 };
 
-const mapCalendarResponse = (res: GaxiosResponse<calendar_v3.Schema$Events>): Promise<CalendarResult[] | null> => {
-    if (!res.data.items) {
-        return Promise.resolve(null);
-    }
-
-    return Promise.all(res.data.items.filter((x) => x.id).map(mapCalendarEvent));
-};
-
 const handler = withSessionContext(async (req: NextApiRequest, res: NextApiResponse): Promise<void> => {
     switch (req.method) {
         case 'GET':
-            await calendarClient.events
-                .list({
-                    calendarId: process.env.CALENDAR_ID,
-                    timeMin: new Date().toISOString(),
-                    maxResults: 135,
-                    singleEvents: true,
-                    orderBy: 'startTime',
-                })
-                .then(mapCalendarResponse)
+            await getCalendarEvents()
                 .then(filterCalendarEvents)
                 .then((result) => res.status(200).json(result))
                 .catch((error) => respondWithCustomErrorMessage(res, error.message));

--- a/src/pages/api/calendar/index.ts
+++ b/src/pages/api/calendar/index.ts
@@ -7,6 +7,7 @@ import { fetchSettings } from '../../../lib/db-access/setting';
 import { withSessionContext } from '../../../lib/sessionContext';
 import { getGlobalSetting } from '../../../lib/utils';
 import { CalendarResult } from '../../../models/misc/CalendarResult';
+import { fetchUserIdByNameTag } from '../../../lib/db-access/user';
 
 const calendarClient = calendar({
     version: 'v3',
@@ -56,6 +57,8 @@ const mapCalendarResponse = (res: GaxiosResponse<calendar_v3.Schema$Events>): Pr
                 start: x.start?.dateTime ?? x.start?.date ?? undefined,
                 end: x.end?.dateTime ?? x.start?.date ?? undefined,
                 existingBookingId: (await fetchFirstBookingByCalendarBookingId(x.id as string))?.id,
+                initials: getNameTagsFromEventName(x.summary ?? ''),
+                workingUsersIds: await getUsersIdsFromEventName(x.summary ?? ''),
             })),
     );
 };
@@ -83,5 +86,24 @@ const handler = withSessionContext(async (req: NextApiRequest, res: NextApiRespo
     }
     return;
 });
+
+const getNameTagsFromEventName = (name: string): string[] => {
+    // Get part of string within [] brackets
+    const match = name.match(/\[(.*?)\]/);
+    if (match) {
+        return match[1]
+            .split(',')
+            .map((x) => (x.includes(':') ? x.split(':')[1] : x))
+            .map((x) => x.trim());
+    }
+    return [];
+};
+
+const getUsersIdsFromEventName = async (name: string): Promise<number[]> => {
+    const nameTags = getNameTagsFromEventName(name ?? '');
+    const users = await Promise.all(nameTags.map(fetchUserIdByNameTag));
+
+    return users.filter((x) => x !== undefined).map((x) => x.id!);
+};
 
 export default handler;

--- a/src/pages/api/calendar/index.ts
+++ b/src/pages/api/calendar/index.ts
@@ -7,7 +7,7 @@ import { fetchSettings } from '../../../lib/db-access/setting';
 import { withSessionContext } from '../../../lib/sessionContext';
 import { getGlobalSetting } from '../../../lib/utils';
 import { CalendarResult } from '../../../models/misc/CalendarResult';
-import { fetchUserIdByNameTag } from '../../../lib/db-access/user';
+import { getNameTagsFromEventName, getUsersIdsFromEventName } from '../../../lib/calenderUtils';
 
 const calendarClient = calendar({
     version: 'v3',
@@ -86,24 +86,5 @@ const handler = withSessionContext(async (req: NextApiRequest, res: NextApiRespo
     }
     return;
 });
-
-const getNameTagsFromEventName = (name: string): string[] => {
-    // Get part of string within [] brackets
-    const match = name.match(/\[(.*?)\]/);
-    if (match) {
-        return match[1]
-            .split(',')
-            .map((x) => (x.includes(':') ? x.split(':')[1] : x))
-            .map((x) => x.trim());
-    }
-    return [];
-};
-
-const getUsersIdsFromEventName = async (name: string): Promise<number[]> => {
-    const nameTags = getNameTagsFromEventName(name ?? '');
-    const users = await Promise.all(nameTags.map(fetchUserIdByNameTag));
-
-    return users.filter((x) => x !== undefined).map((x) => x.id!);
-};
 
 export default handler;

--- a/src/pages/api/calendar/open-hours.ts
+++ b/src/pages/api/calendar/open-hours.ts
@@ -6,6 +6,7 @@ import { fetchSettings } from '../../../lib/db-access/setting';
 import { withSessionContext } from '../../../lib/sessionContext';
 import { getGlobalSetting } from '../../../lib/utils';
 import { CalendarResult } from '../../../models/misc/CalendarResult';
+import { getNameTagsFromEventName, getUsersIdsFromEventName } from '../../../lib/calenderUtils';
 
 const calendarClient = calendar({
     version: 'v3',
@@ -51,6 +52,8 @@ const mapCalendarResponse = (res: GaxiosResponse<calendar_v3.Schema$Events>): Pr
                 link: x.htmlLink ?? undefined,
                 start: x.start?.dateTime ?? x.start?.date ?? undefined,
                 end: x.end?.dateTime ?? x.start?.date ?? undefined,
+                initials: getNameTagsFromEventName(x.summary ?? ''),
+                workingUsersIds: await getUsersIdsFromEventName(x.summary ?? ''),
             })),
     );
 };

--- a/src/pages/api/calendar/open-hours.ts
+++ b/src/pages/api/calendar/open-hours.ts
@@ -6,7 +6,7 @@ import { fetchSettings } from '../../../lib/db-access/setting';
 import { withSessionContext } from '../../../lib/sessionContext';
 import { getGlobalSetting } from '../../../lib/utils';
 import { CalendarResult } from '../../../models/misc/CalendarResult';
-import { getNameTagsFromEventName, getUsersIdsFromEventName } from '../../../lib/calenderUtils';
+import { mapCalendarEvent } from '../../../lib/calenderUtils';
 
 const calendarClient = calendar({
     version: 'v3',
@@ -43,19 +43,7 @@ const mapCalendarResponse = (res: GaxiosResponse<calendar_v3.Schema$Events>): Pr
         return Promise.resolve(null);
     }
 
-    return Promise.all(
-        res.data.items
-            .filter((x) => x.id)
-            .map(async (x) => ({
-                id: x.id as string,
-                name: x.summary ?? undefined,
-                link: x.htmlLink ?? undefined,
-                start: x.start?.dateTime ?? x.start?.date ?? undefined,
-                end: x.end?.dateTime ?? x.start?.date ?? undefined,
-                initials: getNameTagsFromEventName(x.summary ?? ''),
-                workingUsersIds: await getUsersIdsFromEventName(x.summary ?? ''),
-            })),
-    );
+    return Promise.all(res.data.items.filter((x) => x.id).map(mapCalendarEvent));
 };
 
 const handler = withSessionContext(async (req: NextApiRequest, res: NextApiResponse): Promise<void> => {

--- a/src/pages/api/calendar/open-hours.ts
+++ b/src/pages/api/calendar/open-hours.ts
@@ -1,17 +1,10 @@
-import { calendar_v3, calendar } from '@googleapis/calendar';
-import { GaxiosResponse } from 'googleapis-common';
 import { NextApiRequest, NextApiResponse } from 'next';
 import { respondWithCustomErrorMessage, respondWithInvalidMethodResponse } from '../../../lib/apiResponses';
 import { fetchSettings } from '../../../lib/db-access/setting';
 import { withSessionContext } from '../../../lib/sessionContext';
 import { getGlobalSetting } from '../../../lib/utils';
 import { CalendarResult } from '../../../models/misc/CalendarResult';
-import { mapCalendarEvent } from '../../../lib/calenderUtils';
-
-const calendarClient = calendar({
-    version: 'v3',
-    auth: process.env.CALENDAR_API_KEY,
-});
+import { getCalendarEvents } from '../../../lib/calenderUtils';
 
 const filterCalendarEvents = async (events: CalendarResult[] | null) => {
     if (!events) {
@@ -38,26 +31,10 @@ const filterCalendarEvents = async (events: CalendarResult[] | null) => {
     return events.filter(filter);
 };
 
-const mapCalendarResponse = (res: GaxiosResponse<calendar_v3.Schema$Events>): Promise<CalendarResult[] | null> => {
-    if (!res.data.items) {
-        return Promise.resolve(null);
-    }
-
-    return Promise.all(res.data.items.filter((x) => x.id).map(mapCalendarEvent));
-};
-
 const handler = withSessionContext(async (req: NextApiRequest, res: NextApiResponse): Promise<void> => {
     switch (req.method) {
         case 'GET':
-            await calendarClient.events
-                .list({
-                    calendarId: process.env.CALENDAR_ID,
-                    timeMin: new Date().toISOString(),
-                    maxResults: 135,
-                    singleEvents: true,
-                    orderBy: 'startTime',
-                })
-                .then(mapCalendarResponse)
+            await getCalendarEvents()
                 .then(filterCalendarEvents)
                 .then((result) => res.status(200).json(result))
                 .catch((error) => respondWithCustomErrorMessage(res, error.message));

--- a/src/pages/api/sendMessage/toBookingWorkers.ts
+++ b/src/pages/api/sendMessage/toBookingWorkers.ts
@@ -1,0 +1,62 @@
+import { NextApiRequest, NextApiResponse } from 'next';
+import { respondWithCustomErrorMessage, respondWithInvalidDataResponse } from '../../../lib/apiResponses';
+import { SessionContext, withSessionContext } from '../../../lib/sessionContext';
+import { fetchBooking, fetchUser } from '../../../lib/db-access';
+import { notEmpty, onlyUnique } from '../../../lib/utils';
+import { sendSlackMessageToUsersRegardingBookings } from '../../../lib/slack';
+import { getCalendarEvent } from '../../../lib/calenderUtils';
+
+const handler = withSessionContext(
+    async (req: NextApiRequest, res: NextApiResponse, context: SessionContext): Promise<void> => {
+        const bookingId = Number(req.body.bookingId);
+        const message: string = req.body.message;
+
+        if (isNaN(bookingId)) {
+            respondWithInvalidDataResponse(res);
+            return;
+        }
+
+        if (!message || message.length === 0) {
+            respondWithInvalidDataResponse(res);
+            return;
+        }
+
+        if (!context.currentUser.userId) {
+            throw new Error('User not logged in');
+        }
+
+        try {
+            const currentUser = await fetchUser(context.currentUser.userId);
+
+            const booking = await fetchBooking(bookingId);
+
+            if (!booking.calendarBookingId || booking.calendarBookingId.length === 0) {
+                respondWithInvalidDataResponse(res);
+                return;
+            }
+
+            const calenderEvent = await getCalendarEvent(booking.calendarBookingId);
+
+            const currentUserSlackId = currentUser?.slackId;
+            const bookingOwnerSlackId = booking.ownerUser?.slackId;
+            const bookingWorkersSlackIds = calenderEvent.workingUsers?.map((user) => user.slackId);
+
+            const slackIds = [currentUserSlackId, bookingOwnerSlackId, ...bookingWorkersSlackIds]
+                .filter(notEmpty)
+                .filter(onlyUnique);
+
+            if (slackIds.length <= 1) {
+                respondWithInvalidDataResponse(res);
+                return;
+            }
+
+            await sendSlackMessageToUsersRegardingBookings(message, [booking], slackIds);
+
+            res.status(200).json(true);
+        } catch (error) {
+            respondWithCustomErrorMessage(res, (error as { message: string }).message);
+        }
+    },
+);
+
+export default handler;

--- a/src/pages/api/sendMessage/toBookingWorkers.ts
+++ b/src/pages/api/sendMessage/toBookingWorkers.ts
@@ -23,7 +23,6 @@ const handler = withSessionContext(
 
         try {
             const currentUser = await fetchUser(context.currentUser.userId);
-
             const booking = await fetchBookingWithEquipmentLists(bookingId).then(toBooking);
 
             if (!booking.calendarBookingId || booking.calendarBookingId.length === 0) {
@@ -32,12 +31,11 @@ const handler = withSessionContext(
             }
 
             const calenderEvent = await getCalendarEvent(booking.calendarBookingId);
-
+            const bookingWorkersSlackIds = calenderEvent.workingUsers?.map((user) => user.slackId);
             const currentUserSlackId = currentUser?.slackId;
             const bookingOwnerSlackId = booking.ownerUser?.slackId;
-            const bookingWorkersSlackIds = calenderEvent.workingUsers?.map((user) => user.slackId);
 
-            const slackIds = [currentUserSlackId, bookingOwnerSlackId, ...bookingWorkersSlackIds]
+            const slackIds = [...bookingWorkersSlackIds, currentUserSlackId, bookingOwnerSlackId]
                 .filter((x) => !!x && x?.length > 0)
                 .filter(notEmpty)
                 .filter(onlyUnique);

--- a/src/pages/api/sendMessage/toBookingWorkers.ts
+++ b/src/pages/api/sendMessage/toBookingWorkers.ts
@@ -3,7 +3,7 @@ import { respondWithCustomErrorMessage, respondWithInvalidDataResponse } from '.
 import { SessionContext, withSessionContext } from '../../../lib/sessionContext';
 import { fetchUser } from '../../../lib/db-access';
 import { notEmpty, onlyUnique } from '../../../lib/utils';
-import { startSlackChannelWithUsersForBooking } from '../../../lib/slack';
+import { sendMessageToUsersForBooking } from '../../../lib/slack';
 import { getCalendarEvent } from '../../../lib/calenderUtils';
 import { toBooking } from '../../../lib/mappers/booking';
 import { fetchBookingWithEquipmentLists } from '../../../lib/db-access/booking';
@@ -11,6 +11,7 @@ import { fetchBookingWithEquipmentLists } from '../../../lib/db-access/booking';
 const handler = withSessionContext(
     async (req: NextApiRequest, res: NextApiResponse, context: SessionContext): Promise<void> => {
         const bookingId = Number(req.body.bookingId);
+        const startSlackChannel = req.body.startSlackChannel === true;
 
         if (isNaN(bookingId)) {
             respondWithInvalidDataResponse(res);
@@ -45,7 +46,7 @@ const handler = withSessionContext(
                 return;
             }
 
-            await startSlackChannelWithUsersForBooking(booking, slackIds);
+            await sendMessageToUsersForBooking(booking, startSlackChannel, slackIds, calenderEvent.link);
 
             res.status(200).json(true);
         } catch (error) {

--- a/src/pages/bookings/[id]/index.tsx
+++ b/src/pages/bookings/[id]/index.tsx
@@ -185,7 +185,6 @@ const BookingPage: React.FC<Props> = ({ user: currentUser, globalSettings }: Pro
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({
                 bookingId: booking.id,
-                message: `Denna kanal har automatiskt skapats för bokningen *${booking.name}* som äger rum ${formatDateForForm(booking.usageStartDatetime)}. Här kan ni diskutera bokningen och dela viktig information.`,
             }),
         };
 

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -56,7 +56,7 @@ const IndexPage: React.FC<Props> = ({ user: currentUser, globalSettings }: Props
                     <TinyBookingTable title="Mina bokningar" bookings={myDraftOrBookedBookings}>
                         <IfNotReadonly currentUser={currentUser}>
                             <Link href="/bookings/new" passHref>
-                                <Button variant="secondary" as="span" className="mr-2 ml-2 mb-2">
+                                <Button size="sm" variant="secondary" as="span" className="mr-2 ml-2 mb-2">
                                     <FontAwesomeIcon icon={faAdd} className="mr-1" /> Lägg till bokning
                                 </Button>
                             </Link>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -22,7 +22,7 @@ import { IfNotReadonly } from '../components/utils/IfAdmin';
 import TableStyleLink from '../components/utils/TableStyleLink';
 import { KeyValue } from '../models/interfaces/KeyValue';
 import CurrentlyOutEquipment from '../components/CurrentlyOutEquipment';
-import ManageCoOwnerBookingsButton from '../components/ManageCoOwnerBookingsButton';
+import AddUserAsCoOwnerToAllFutureBookingsForUserButton from '../components/AddUserAsCoOwnerToAllFutureBookingsForUserButton';
 
 // eslint-disable-next-line react-hooks/rules-of-hooks
 export const getServerSideProps = useUserWithDefaultAccessAndWithSettings();
@@ -68,7 +68,7 @@ const IndexPage: React.FC<Props> = ({ user: currentUser, globalSettings }: Props
                         tableSettingsOverride={{ defaultSortAscending: false }}
                     >
                         <div>
-                            <ManageCoOwnerBookingsButton
+                            <AddUserAsCoOwnerToAllFutureBookingsForUserButton
                                 className="mr-2 ml-2 mb-2"
                                 currentUser={currentUser}
                                 currentCoOwnerBookings={coOwnerBookings ?? []}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -22,6 +22,7 @@ import { IfNotReadonly } from '../components/utils/IfAdmin';
 import TableStyleLink from '../components/utils/TableStyleLink';
 import { KeyValue } from '../models/interfaces/KeyValue';
 import CurrentlyOutEquipment from '../components/CurrentlyOutEquipment';
+import ManageCoOwnerBookingsButton from '../components/ManageCoOwnerBookingsButton';
 
 // eslint-disable-next-line react-hooks/rules-of-hooks
 export const getServerSideProps = useUserWithDefaultAccessAndWithSettings();
@@ -30,7 +31,10 @@ type Props = { user: CurrentUserInfo; globalSettings: KeyValue[] };
 const IndexPage: React.FC<Props> = ({ user: currentUser, globalSettings }: Props) => {
     const { data: bookings } = useSwr('/api/bookings', bookingsFetcher);
     const { data: myBookings } = useSwr('/api/users/' + currentUser.userId + '/bookings', bookingsFetcher);
-    const { data: coOwnerBookings } = useSwr('/api/users/' + currentUser.userId + '/coOwnerBookings', bookingsFetcher);
+    const { data: coOwnerBookings, mutate: mutateCoOwnerBookings } = useSwr(
+        '/api/users/' + currentUser.userId + '/coOwnerBookings',
+        bookingsFetcher,
+    );
 
     const myDraftOrBookedBookings = myBookings?.map(toBookingViewModel).filter(IsBookingDraftOrBooked);
     const upcomingRentalBookings = bookings?.map(toBookingViewModel).filter(IsBookingUpcomingRental);
@@ -62,7 +66,16 @@ const IndexPage: React.FC<Props> = ({ user: currentUser, globalSettings }: Props
                         title="Mina favoritbokningar"
                         bookings={coOwnerBookings}
                         tableSettingsOverride={{ defaultSortAscending: false }}
-                    ></TinyBookingTable>
+                    >
+                        <div>
+                            <ManageCoOwnerBookingsButton
+                                className="mr-2 ml-2 mb-2"
+                                currentUser={currentUser}
+                                currentCoOwnerBookings={coOwnerBookings ?? []}
+                                mutate={mutateCoOwnerBookings}
+                            />
+                        </div>
+                    </TinyBookingTable>
                 </Col>
                 <Col xl={6}>
                     <TinyBookingTable


### PR DESCRIPTION
At the meeting yesterday we discussed fetching the users working bookings from the calendar, by parsing the prefix of the calendar event name. This is a POC of that, which includes three features:

* Save all bookings I will work at as favorites (aka _coOwnerBookings_)
* Show which users are signed up in the calendar for an event connected to booking
* Create a slack channel or start DM-group for a booking

All of these are built on top of a new field in the calendar event endpoint: WorkingUsers. This field is populated by identifying the user name tags in the brackets at the start of the calendar event name (using regex, comma separation, and substrings to try to remove noise). These tags are then matched with the stage user database to find any matches.

**Save all booking I will work at as favorites:**

When a user presses the button the system searches though the next 135 (same limit as when creating bookings or looking for bemanning-occurances) calendar events. If the user is identified as a WorkingUser of any of these, the corresponding booking are added as a favorite (if not already a favorite). Note that old bookings are not removed automatically.

![image](https://github.com/user-attachments/assets/ea684805-a06b-4151-9e9c-c3f37b8595a9)
![image](https://github.com/user-attachments/assets/cff5aa64-0ffa-4dc9-ae0b-d0b9d78eb3c3)
![image](https://github.com/user-attachments/assets/f9e9f07a-b910-4de5-bfe8-99147d021fee)

As a part of this, to make the UI more consistent, I also moved the "+ Lägg till bokning"-button to the top-right (from the bottom left):
![image](https://github.com/user-attachments/assets/c2e4f25c-129c-4d37-94e8-74cb99668d6b)

**Show which users are signed up in the calendar for an event connected to booking**

There is a new section on the booking page for giggs "Uppskrivna i kalendern". This section shows which users are signed up in the calendar based on the name tags. Users are shown with their name tags and member status, and asps have a seperate icon. If no matching user is found, only the tag is shown and the icon changes to a questionmark. There is a new system setting "googleCalendar.nameTagBlackList" to remove tags like "Många", "Alla", "Intern", and "Hyra".

Since the users working the booking is quite important, I made the somewhat controversial decition to place this section at the top for now. I'm not sure this is reasonable, maybe it fits better below with the google drive and notes sections. We can discuss the placement further.


![image](https://github.com/user-attachments/assets/1d272051-8f1b-445d-8116-28748649c77b)
![image](https://github.com/user-attachments/assets/e4562915-dc77-4aa4-95dd-bfa39825f101)
![image](https://github.com/user-attachments/assets/bd127dce-0b7c-416c-8e1d-e8f01030dd74)


**Create a slack channel or start a DM-group for a booking:**

In the above mentioned new section there is a mer menu with options for contacting the workers by either DM ("Skicka direktmeddelande till de som jobbar") or by creating a slack channel ("Skapa slackkanal med de som jobbar"). When pressed, the system starts a DM group with the users or creates a new slack channel with the name "gigg-[booking-name]-[booking-date]" (if it doesn't already exist) and invites all users identified as working the booking (if not already in the channel). In addition to the users working the booking, the booking owner and the user creating the channel are invited as well. The feature is only available for giggs with a calendar connection, and will of course only work for users with slack ids configured.

A message with basic booking information and links are as the channel is created (or in the existing channel, if applicable). In this POC, the message is static and cannot be changed either by admins or by the user triggering the channel creation. Also, the channel id is not stored, so if the name or date changes and the button is pressed again a new channel will be created reflecting the new info.

![image](https://github.com/user-attachments/assets/c2debe63-7f02-4db4-90ea-a9cbf617c0a8)
![image](https://github.com/user-attachments/assets/84f660e3-cbd8-4fa9-8c14-589ee4dafcac)
![image](https://github.com/user-attachments/assets/9508fcfa-0896-4f89-80cf-4336ac74baf6)

Note that additional OAuth scopes are needed:
![image](https://github.com/user-attachments/assets/a4ad0ca1-5b82-4c15-a214-ab696b0db4c8)

I welcome any feedback, especially regarding the labeling of these new features in the UX and the message content 😊

