### PR TITLE
Feature: open searchresult in new tab

### DIFF
--- a/src/components/layout/Search.tsx
+++ b/src/components/layout/Search.tsx
@@ -181,6 +181,7 @@ const Search: React.FC<Props> = ({ onFocus, onBlur }: Props) => {
                             option={entity}
                             position={entity.index}
                             className={styles.dropdownItem}
+							href={entity.url}
                         >
                             <SplitHighlighter search={state.text} textToHighlight={entity.name} />
                             <div>{getDescription(entity, state.text)}</div>


### PR DESCRIPTION
set href on the Typehead MenuItem used for the search result which lets the browswer knows that it links to a url which can be used to open in a new tab.