### PR TITLE
Feature: Calendar event selection on existing booking

### DIFF
--- a/src/components/bookings/CalendarWorkersCard.tsx
+++ b/src/components/bookings/CalendarWorkersCard.tsx
@@ -156,30 +156,32 @@ const CalendarWorkersCardWithCalendarConnection: React.FC<CalendarWorkersCardWit
                 <Button className="mr-2" variant="" size="sm" onClick={() => setShowContent((x) => !x)}>
                     <FontAwesomeIcon icon={showContent ? faAngleUp : faAngleDown} />
                 </Button>
-                {!readonly ? (
-                    <DropdownButton id="dropdown-basic-button" variant="secondary" title="Mer" size="sm">
-                        {!readonly && workingUsers.length > 0 ? (
-                            <>
-                                <Dropdown.Item onClick={() => sendMessageToCalendarWorkers(false)}>
-                                    <FontAwesomeIcon icon={faMessage} className="mr-1 fa-fw" /> Skicka direktmeddelande
-                                    till de som jobbar
-                                </Dropdown.Item>
-                                <Dropdown.Item onClick={() => sendMessageToCalendarWorkers(true)}>
-                                    <FontAwesomeIcon icon={faHashtag} className="mr-1 fa-fw" /> Skapa slackkanal med de
-                                    som jobbar
-                                </Dropdown.Item>
-                                <Dropdown.Divider />
-                                <Dropdown.Item onClick={() => setShowSelectCalendarEventModal(true)}>
-                                    <FontAwesomeIcon icon={faCalendar} className="mr-1 fa-fw" /> Redigara koppling till
-                                    kalenderevent
-                                </Dropdown.Item>
-                            </>
-                        ) : null}
-                        <Dropdown.Item href={data?.link} target="_blank">
-                            <FontAwesomeIcon icon={faExternalLinkAlt} className="mr-1 fa-fw" /> Öppna i Google Calendar
-                        </Dropdown.Item>
-                    </DropdownButton>
-                ) : null}
+                <DropdownButton id="dropdown-basic-button" variant="secondary" title="Mer" size="sm">
+                    {!readonly && workingUsers.length > 0 ? (
+                        <>
+                            <Dropdown.Item onClick={() => sendMessageToCalendarWorkers(false)}>
+                                <FontAwesomeIcon icon={faMessage} className="mr-1 fa-fw" /> Skicka direktmeddelande
+                                till de som jobbar
+                            </Dropdown.Item>
+                            <Dropdown.Item onClick={() => sendMessageToCalendarWorkers(true)}>
+                                <FontAwesomeIcon icon={faHashtag} className="mr-1 fa-fw" /> Skapa slackkanal med de
+                                som jobbar
+                            </Dropdown.Item>
+                        </>
+                    ) : null}
+                    {!readonly ? (
+                        <>
+                            <Dropdown.Item onClick={() => setShowSelectCalendarEventModal(true)}>
+                                <FontAwesomeIcon icon={faCalendar} className="mr-1 fa-fw" /> Redigara koppling till
+                                kalenderevent
+                            </Dropdown.Item>
+                            <Dropdown.Divider />
+                        </>
+                    ) : null}
+                    <Dropdown.Item href={data?.link} target="_blank">
+                        <FontAwesomeIcon icon={faExternalLinkAlt} className="mr-1 fa-fw" /> Öppna i Google Calendar
+                    </Dropdown.Item>
+                </DropdownButton>
                 {showSelectCalendarEventModal ? (
                     <SelectCalendarEventModal
                         show={showSelectCalendarEventModal}
@@ -290,6 +292,7 @@ const SelectCalendarEventModal: React.FC<SelectCalendarEventModalProps> = ({
     }
 
     const previousCalendarEvent = bookingsCalendarList.find((x) => x.key == value);
+    const cannotFindConnectedEvent = value && !previousCalendarEvent;
 
     return (
         <Modal show={show} onHide={hide}>
@@ -297,7 +300,7 @@ const SelectCalendarEventModal: React.FC<SelectCalendarEventModalProps> = ({
                 <Modal.Title>Välj kalenderevent</Modal.Title>
             </Modal.Header>
             <Modal.Body>
-                {value && !previousCalendarEvent ? (
+                {cannotFindConnectedEvent ? (
                     <Alert variant="warning" className="mb-3">
                         <FontAwesomeIcon icon={faExclamationCircle} className="mr-2" />
                         Denna bokning är kopplad till ett okänt kalenderevent som har passerat eller tagits inte längre
@@ -310,7 +313,7 @@ const SelectCalendarEventModal: React.FC<SelectCalendarEventModalProps> = ({
                     value={selectedCalendarEvent}
                     onChange={(e) => setSelectedCalendarEvent(e.target.value)}
                 >
-                    {!previousCalendarEvent ? (
+                    {cannotFindConnectedEvent ? (
                         <option value={selectedCalendarEvent}>Okänt event ({value})</option>
                     ) : null}
                     <option value="">Ingen koppling till kalenderevent</option>

--- a/src/components/bookings/CalendarWorkersCard.tsx
+++ b/src/components/bookings/CalendarWorkersCard.tsx
@@ -160,12 +160,12 @@ const CalendarWorkersCardWithCalendarConnection: React.FC<CalendarWorkersCardWit
                     {!readonly && workingUsers.length > 0 ? (
                         <>
                             <Dropdown.Item onClick={() => sendMessageToCalendarWorkers(false)}>
-                                <FontAwesomeIcon icon={faMessage} className="mr-1 fa-fw" /> Skicka direktmeddelande
-                                till de som jobbar
+                                <FontAwesomeIcon icon={faMessage} className="mr-1 fa-fw" /> Skicka direktmeddelande till
+                                de som jobbar
                             </Dropdown.Item>
                             <Dropdown.Item onClick={() => sendMessageToCalendarWorkers(true)}>
-                                <FontAwesomeIcon icon={faHashtag} className="mr-1 fa-fw" /> Skapa slackkanal med de
-                                som jobbar
+                                <FontAwesomeIcon icon={faHashtag} className="mr-1 fa-fw" /> Skapa slackkanal med de som
+                                jobbar
                             </Dropdown.Item>
                         </>
                     ) : null}

--- a/src/components/bookings/CalendarWorkersCard.tsx
+++ b/src/components/bookings/CalendarWorkersCard.tsx
@@ -303,7 +303,7 @@ const SelectCalendarEventModal: React.FC<SelectCalendarEventModalProps> = ({
                 {cannotFindConnectedEvent ? (
                     <Alert variant="warning" className="mb-3">
                         <FontAwesomeIcon icon={faExclamationCircle} className="mr-2" />
-                        Denna bokning är kopplad till ett okänt kalenderevent som har passerat eller tagits inte längre
+                        Denna bokning är kopplad till ett okänt kalenderevent som har passerats eller inte längre
                         finns.
                         <p className="text-monospace mt-2 mb-0">Id: {value}</p>
                     </Alert>

--- a/src/pages/bookings/[id]/index.tsx
+++ b/src/pages/bookings/[id]/index.tsx
@@ -365,6 +365,7 @@ const BookingPage: React.FC<Props> = ({ user: currentUser, globalSettings }: Pro
                         <CalendarWorkersCard
                             bookingId={booking.id}
                             calendarEventId={booking.calendarBookingId}
+                            onSubmit={(calendarBookingId) => saveBooking({ calendarBookingId })}
                             readonly={readonly}
                         />
                     ) : null}


### PR DESCRIPTION
Add button to connect a calendar event, if it does not already exist. If a connection exists, the same menu can be accessed from the Mer-dropdown which enabled the user to change the connected calendar event. The UI to select is the same as is used for the bemanning-wizard-feature.

Since we only fetch future events from the calendar API, we show a warning message if the user tries to edit a connection for which we cannot find the current value in the list of future calendar events.

Booking without calendar connection:
![image](https://github.com/user-attachments/assets/76c4dacb-e1cf-467c-ad18-85fe297bee5b)

Booking with existing calendar connection:
![image](https://github.com/user-attachments/assets/cff3721d-edee-4b1d-86e7-0e95f1b840be)

Edit modal:
![image](https://github.com/user-attachments/assets/4e121e23-ddc3-487a-a744-7231a6045cd9)

Warning message described above:
![image](https://github.com/user-attachments/assets/641e4042-3205-41a3-b7cc-c235fb062de1)
