### PR TITLE
Feature: Add option to show rental controls on gigs

### DIFF
--- a/src/components/bookings/BookingRentalStatusButton.tsx
+++ b/src/components/bookings/BookingRentalStatusButton.tsx
@@ -40,7 +40,11 @@ const BookingRentalStatusButton: React.FC<Props> = ({
                 : booking.returnalNote,
         });
 
-    if (booking.bookingType === BookingType.GIG || alwaysShowRentalControls) {
+    if (
+        booking.bookingType === BookingType.GIG &&
+        !booking.equipmentLists?.some((list) => list.rentalStatus == RentalStatus.OUT) &&
+        !alwaysShowRentalControls
+    ) {
         return null;
     }
 

--- a/src/components/bookings/BookingRentalStatusButton.tsx
+++ b/src/components/bookings/BookingRentalStatusButton.tsx
@@ -14,10 +14,16 @@ import { Status } from '../../models/enums/Status';
 type Props = {
     booking: Partial<Booking>;
     onChange: (booking: PartialDeep<IBookingObjectionModel, { recurseIntoArrays: true }>) => void;
+    alwaysShowRentalControls: boolean;
     className?: string;
 };
 
-const BookingRentalStatusButton: React.FC<Props> = ({ booking, onChange, className }: Props) => {
+const BookingRentalStatusButton: React.FC<Props> = ({
+    booking,
+    onChange,
+    className,
+    alwaysShowRentalControls,
+}: Props) => {
     const [showConfirmOutModal, setShowConfirmOutModal] = useState(false);
     const [showReturnalNoteModal, setShowReturnalNoteModal] = useState(false);
 
@@ -34,7 +40,7 @@ const BookingRentalStatusButton: React.FC<Props> = ({ booking, onChange, classNa
                 : booking.returnalNote,
         });
 
-    if (booking.bookingType === BookingType.GIG) {
+    if (booking.bookingType === BookingType.GIG || alwaysShowRentalControls) {
         return null;
     }
 

--- a/src/components/bookings/equipmentLists/EquipmentList.tsx
+++ b/src/components/bookings/equipmentLists/EquipmentList.tsx
@@ -52,6 +52,7 @@ type Props = {
     moveListFn: (x: EquipmentList, direction: 'UP' | 'DOWN') => void;
     isFirstFn: (x: EquipmentList) => boolean;
     isLastFn: (x: EquipmentList) => boolean;
+    alwaysShowRentalControls: boolean;
     globalSettings: KeyValue[];
 };
 
@@ -63,6 +64,7 @@ const EquipmentListDisplay: React.FC<Props> = ({
     moveListFn: parentMoveListFn,
     isFirstFn: parentIsFirstFn,
     isLastFn: parentIsLastFn,
+    alwaysShowRentalControls,
     readonly,
     globalSettings,
 }: Props) => {
@@ -418,6 +420,7 @@ const EquipmentListDisplay: React.FC<Props> = ({
                     disableMoveUp={parentIsFirstFn(list)}
                     disableMoveDown={parentIsLastFn(list)}
                     disableDelete={otherLists.length === 0}
+                    alwaysShowRentalControls={alwaysShowRentalControls}
                     readonly={readonly}
                 />
             </Card.Header>

--- a/src/components/bookings/equipmentLists/EquipmentListHeader.tsx
+++ b/src/components/bookings/equipmentLists/EquipmentListHeader.tsx
@@ -67,6 +67,7 @@ type Props = {
     disableMoveUp: boolean;
     disableMoveDown: boolean;
     disableDelete: boolean;
+    alwaysShowRentalControls: boolean;
     readonly: boolean;
 };
 
@@ -91,6 +92,7 @@ const EquipmentListHeader: React.FC<Props> = ({
     disableMoveUp,
     disableMoveDown,
     disableDelete,
+    alwaysShowRentalControls,
     readonly,
 }: Props) => {
     const [showEmptyListModal, setShowEmptyListModal] = useState(false);
@@ -125,6 +127,8 @@ const EquipmentListHeader: React.FC<Props> = ({
         return 'text-muted';
     };
 
+    const showRentalControls = bookingType === BookingType.RENTAL || alwaysShowRentalControls;
+
     // HTML template
     //
     return (
@@ -150,7 +154,7 @@ const EquipmentListHeader: React.FC<Props> = ({
                     </Button>
                     {readonly ? null : (
                         <>
-                            {bookingType === BookingType.RENTAL && list.rentalStatus == undefined ? (
+                            {showRentalControls && list.rentalStatus == undefined ? (
                                 <>
                                     <Button
                                         variant="secondary"
@@ -183,7 +187,7 @@ const EquipmentListHeader: React.FC<Props> = ({
                                 </>
                             ) : null}
 
-                            {bookingType === BookingType.RENTAL && list.rentalStatus == RentalStatus.OUT ? (
+                            {list.rentalStatus == RentalStatus.OUT ? (
                                 <>
                                     <Button
                                         variant="secondary"
@@ -325,7 +329,7 @@ const EquipmentListHeader: React.FC<Props> = ({
                                     </Dropdown.Item>
                                 )}
 
-                                {bookingType === BookingType.RENTAL ? (
+                                {showRentalControls ? (
                                     <Dropdown.Item
                                         onClick={() => saveList({ ...list, rentalStatus: null })}
                                         disabled={list.rentalStatus == undefined}
@@ -401,7 +405,7 @@ const EquipmentListHeader: React.FC<Props> = ({
                         / {getNumberOfEquipmentOutDays(list)} dagar / {getNumberOfDays(list)} debiterade dagar
                     </>
                 ) : null}
-                {bookingType === BookingType.RENTAL ? <> / {getRentalStatusName(list.rentalStatus)}</> : null}
+                {showRentalControls ? <> / {getRentalStatusName(list.rentalStatus)}</> : null}
                 {list.discountPercentage !== 0 ? (
                     <>
                         {' '}

--- a/src/components/bookings/equipmentLists/EquipmentLists.tsx
+++ b/src/components/bookings/equipmentLists/EquipmentLists.tsx
@@ -29,13 +29,20 @@ type Props = {
     bookingId: number;
     readonly: boolean;
     defaultLaborHourlyRate: number;
+    alwaysShowRentalControls: boolean;
     globalSettings: KeyValue[];
 };
 
 // This component only contains logic to create and delete lists. Everything else
 // is handled by the EquipmentListDisplay component which manages it's list internally.
 //
-const EquipmentLists: React.FC<Props> = ({ bookingId, readonly, defaultLaborHourlyRate, globalSettings }: Props) => {
+const EquipmentLists: React.FC<Props> = ({
+    bookingId,
+    readonly,
+    defaultLaborHourlyRate,
+    alwaysShowRentalControls,
+    globalSettings,
+}: Props) => {
     const { data: booking, mutate, error } = useSwr('/api/bookings/' + bookingId, (url) => bookingFetcher(url));
 
     const {
@@ -190,6 +197,7 @@ const EquipmentLists: React.FC<Props> = ({ bookingId, readonly, defaultLaborHour
                     isFirstFn={(list: EquipmentList) => isFirst(equipmentLists, list)}
                     isLastFn={(list: EquipmentList) => isLast(equipmentLists, list)}
                     globalSettings={globalSettings}
+                    alwaysShowRentalControls={alwaysShowRentalControls}
                 />
             ))}
             {readonly ? null : (

--- a/src/pages/bookings/[id]/index.tsx
+++ b/src/pages/bookings/[id]/index.tsx
@@ -9,6 +9,7 @@ import {
     getPricePlanName,
     getResponseContentOrError,
     getOperationalYear,
+    getBookingTypeName,
 } from '../../../lib/utils';
 import { CurrentUserInfo } from '../../../models/misc/CurrentUserInfo';
 import { useUserWithDefaultAccessAndWithSettings } from '../../../lib/useUser';
@@ -30,6 +31,8 @@ import {
     faLockOpen,
     faPen,
     faTimesCircle,
+    faToggleOff,
+    faToggleOn,
     faTrashCan,
 } from '@fortawesome/free-solid-svg-icons';
 import { Role } from '../../../models/enums/Role';
@@ -75,6 +78,7 @@ const BookingPage: React.FC<Props> = ({ user: currentUser, globalSettings }: Pro
     // const [showConfirmReadyForCashPaymentModal, setShowConfirmReadyForCashPaymentModal] = useState(false);
     const [showConfirmPaidModal, setShowConfirmPaidModal] = useState(false);
     const [adminEditModeOverrideEnabled, setAdminEditModeOverrideEnabled] = useState(false);
+    const [alwaysShowRentalControls, setAlwaysShowRentalControls] = useState(false);
     const [showDeleteModal, setShowDeleteModal] = useState(false);
     const [showCancelModal, setShowCancelModal] = useState(false);
 
@@ -198,7 +202,11 @@ const BookingPage: React.FC<Props> = ({ user: currentUser, globalSettings }: Pro
                         </Link>
 
                         <BookingStatusButton booking={booking} onChange={saveBooking} />
-                        <BookingRentalStatusButton booking={booking} onChange={saveBooking} />
+                        <BookingRentalStatusButton
+                            booking={booking}
+                            onChange={saveBooking}
+                            alwaysShowRentalControls={alwaysShowRentalControls}
+                        />
                     </>
                 ) : null}
                 <Dropdown as={ButtonGroup}>
@@ -301,6 +309,18 @@ const BookingPage: React.FC<Props> = ({ user: currentUser, globalSettings }: Pro
 
                 {!readonly ? (
                     <DropdownButton id="dropdown-basic-button" variant="secondary" title="Mer">
+                        {booking.bookingType === BookingType.GIG && !alwaysShowRentalControls ? (
+                            <Dropdown.Item onClick={() => setAlwaysShowRentalControls(true)}>
+                                <FontAwesomeIcon icon={faToggleOff} className="mr-1" /> Visa hyreskontroller för detta{' '}
+                                {getBookingTypeName(booking.bookingType)}
+                            </Dropdown.Item>
+                        ) : null}
+                        {booking.bookingType === BookingType.GIG && alwaysShowRentalControls ? (
+                            <Dropdown.Item onClick={() => setAlwaysShowRentalControls(false)}>
+                                <FontAwesomeIcon icon={faToggleOn} className="mr-1" /> Sluta visa hyreskontroller för
+                                detta {getBookingTypeName(booking.bookingType)}
+                            </Dropdown.Item>
+                        ) : null}
                         {booking.status !== Status.CANCELED && booking.status !== Status.DONE ? (
                             <Dropdown.Item onClick={() => setShowCancelModal(true)}>
                                 <FontAwesomeIcon icon={faTimesCircle} className="mr-1" /> Ställ in bokningen
@@ -357,6 +377,7 @@ const BookingPage: React.FC<Props> = ({ user: currentUser, globalSettings }: Pro
                         readonly={readonly}
                         globalSettings={globalSettings}
                         defaultLaborHourlyRate={defaultLaborHourlyRate}
+                        alwaysShowRentalControls={alwaysShowRentalControls}
                     />
                 </Col>
                 <Col xl={4}>


### PR DESCRIPTION
Add an option to show rental controls ("Lämna ut" and "Ta emot", etc) on gigs. This is to handle the large gigs where the equipment is either sent out in batches beforehand or fetched by the customer, where it would be helpful to track the status.

Note that rental agreements where previously available for rentals as well, this pull request only enables users to use the list rental status tracking for gigs.

New button available:
![image](https://github.com/user-attachments/assets/a1f02f3d-cf70-49ea-beb6-7e95e52ade34)

When clicked:
![image](https://github.com/user-attachments/assets/98cefeab-9577-499a-89f4-8d6fc25f14f3)

Note that the button only adjusts the current session. If you leave the page and return the rental controls will be hidden again. However, the return list button is always available for lists which are marked as out (regardless of booking type and if the new button as been clicked or not).
