### PR TITLE
Feature: Add internal reservation bool to bookings

### DIFF
--- a/knex/migrations/20250531000000_internalReservation.js
+++ b/knex/migrations/20250531000000_internalReservation.js
@@ -1,0 +1,11 @@
+export function up(knex) {
+    return knex.schema.alterTable('Booking', (table) => {
+        table.bool('internalReservation').notNullable().defaultTo(0);
+    });
+}
+
+export function down(knex) {
+    return knex.schema.alterTable('Booking', (table) => {
+        table.dropColumn('internalReservation');
+    });
+}

--- a/src/components/LargeBookingTable.tsx
+++ b/src/components/LargeBookingTable.tsx
@@ -21,6 +21,7 @@ import AdvancedFilters from './AdvancedFilters';
 import BookingStatusTag from './utils/BookingStatusTag';
 import { useSessionStorageState, useSessionStorageStateForDate } from '../lib/useSessionStorageState';
 import FixedPriceStatusTag from './utils/FixedPriceStatusTag';
+import InternalReservationTag from './utils/InternalReservationTag';
 
 const BookingNameDisplayFn = (booking: BookingViewModel) => (
     <>
@@ -29,6 +30,7 @@ const BookingNameDisplayFn = (booking: BookingViewModel) => (
         <BookingStatusTag booking={booking} className="ml-1" />
         <BookingTypeTag booking={booking} className="ml-1" />
         <RentalStatusTag booking={booking} className="ml-1" />
+        <InternalReservationTag booking={booking} className="ml-1" />
         <FixedPriceStatusTag booking={booking} className="ml-1" />
         <p className="text-muted mb-0">{booking.customerName ?? '-'}</p>
     </>

--- a/src/components/TinyBookingTable.tsx
+++ b/src/components/TinyBookingTable.tsx
@@ -10,6 +10,7 @@ import RentalStatusTag from './utils/RentalStatusTag';
 import { getBookingDateHeadingValue, toBookingViewModel } from '../lib/datetimeUtils';
 import BookingStatusTag from './utils/BookingStatusTag';
 import FixedPriceStatusTag from './utils/FixedPriceStatusTag';
+import InternalReservationTag from './utils/InternalReservationTag';
 
 type Props = {
     title: string;
@@ -26,6 +27,7 @@ const BookingNameDisplayFn = (booking: BookingViewModel) => (
         <BookingStatusTag booking={booking} className="ml-1" />
         <BookingTypeTag booking={booking} className="ml-1" />
         <RentalStatusTag booking={booking} className="ml-1" />
+        <InternalReservationTag booking={booking} className="ml-1" />
         <FixedPriceStatusTag booking={booking} className="ml-1" />
         <p className="text-muted mb-0">{booking.customerName ?? '-'}</p>
     </>

--- a/src/components/admin/AdminBookingList.tsx
+++ b/src/components/admin/AdminBookingList.tsx
@@ -25,6 +25,7 @@ import TableStyleLink from '../utils/TableStyleLink';
 import { formatDateForForm, getBookingDateHeadingValue } from '../../lib/datetimeUtils';
 import { addVAT, formatCurrency, getBookingPrice } from '../../lib/pricingUtils';
 import CancelledIcon from '../utils/CancelledIcon';
+import InternalReservationTag from '../utils/InternalReservationTag';
 
 type Props = {
     bookings: BookingViewModel[];
@@ -108,6 +109,7 @@ const AdminBookingList: React.FC<Props> = ({
                 </TableStyleLink>
 
                 <BookingTypeTag booking={booking} className="mr-1" />
+                <InternalReservationTag booking={booking} className="mr-1" />
                 <FixedPriceStatusTag booking={booking} className="mr-1" />
 
                 {customAccountsOnBooking.length > 0 ? (

--- a/src/components/bookings/BookingForm.tsx
+++ b/src/components/bookings/BookingForm.tsx
@@ -65,6 +65,7 @@ const BookingForm: React.FC<Props> = ({
 
         const form = event.currentTarget;
         const getValueFromForm = (key: string): string | undefined => form[key]?.value;
+        const getCheckedFromForm = (key: string): boolean | undefined => form[key]?.checked;
 
         if (
             !replaceEmptyStringWithNull(getValueFromForm('invoiceHogiaId')) &&
@@ -117,6 +118,7 @@ const BookingForm: React.FC<Props> = ({
             invoiceDate: toDatetimeOrUndefined(getValueFromForm('invoiceDate'))
                 ? getValueFromForm('invoiceDate')
                 : null,
+            internalReservation: getCheckedFromForm('internalReservation') ?? booking.internalReservation,
         };
 
         handleSubmitBooking(modifiedBooking);
@@ -575,6 +577,24 @@ const BookingForm: React.FC<Props> = ({
                                     name="invoiceDate"
                                     defaultValue={formatDateForForm(booking?.invoiceDate)}
                                 />
+                            </Form.Group>
+                        </Col>
+                        <Col lg={6}>
+                            <Form.Group controlId="internalReservation">
+                                <Form.Check
+                                    type="checkbox"
+                                    label={'Intern reservation av utrustning'}
+                                    name="internalReservation"
+                                    defaultChecked={booking.internalReservation ?? false}
+                                    id="internal-reservation-checkbox"
+                                />
+
+                                <Form.Text className="text-muted">
+                                    Markera denna checkruta om denna bokning inte är till för utrustningsanvändning utan
+                                    reserverar utrustning för fast installation, reparation, eller annan aktivitet som
+                                    hindrar att den används i normal verksamhet. Om denna checkruta är aktiv exkluderas
+                                    bokningen från listan över utlämnad utrustning, statistik, etc.
+                                </Form.Text>
                             </Form.Group>
                         </Col>
                     </Row>

--- a/src/components/bookings/BookingInfoSection.tsx
+++ b/src/components/bookings/BookingInfoSection.tsx
@@ -8,6 +8,7 @@ import BookingStatusTag from '../utils/BookingStatusTag';
 import BookingTypeTag from '../utils/BookingTypeTag';
 import RentalStatusTag from '../utils/RentalStatusTag';
 import FixedPriceStatusTag from '../utils/FixedPriceStatusTag';
+import InternalReservationTag from '../utils/InternalReservationTag';
 
 type Props = {
     booking: BookingViewModel;
@@ -31,6 +32,7 @@ const BookingInfoSection: React.FC<Props> = ({ booking, className, showName = tr
                 <Badge variant="dark" className="ml-1">
                     {getPaymentStatusName(booking.paymentStatus)}
                 </Badge>
+                <InternalReservationTag booking={booking} className="ml-1" />
                 {booking.language !== Language.SV ? (
                     <Badge variant="dark" className="ml-1">
                         {getLanguageName(booking.language)}

--- a/src/components/utils/InternalReservationTag.tsx
+++ b/src/components/utils/InternalReservationTag.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { Badge } from 'react-bootstrap';
+
+type Props = {
+    booking: { internalReservation: boolean };
+    className?: string;
+};
+
+const InternalReservationTag: React.FC<Props> = ({ booking, className }: Props) =>
+    booking.internalReservation ? (
+        <Badge className={className} variant="dark">
+            Intern reservation
+        </Badge>
+    ) : null;
+export default InternalReservationTag;

--- a/src/lib/db-access/equipmentList.ts
+++ b/src/lib/db-access/equipmentList.ts
@@ -51,17 +51,17 @@ export const fetchOutEquipmentLists = async (): Promise<EquipmentListObjectionMo
 
     return EquipmentListObjectionModel.query()
         .join('Booking', 'Booking.id', '=', 'EquipmentList.bookingId')
-        .where({ rentalStatus: RentalStatus.OUT, bookingType: BookingType.RENTAL })
+        .where({ rentalStatus: RentalStatus.OUT, bookingType: BookingType.RENTAL, internalReservation: false })
         .orWhere((x) =>
             x
-                .where({ bookingType: BookingType.GIG })
+                .where({ bookingType: BookingType.GIG, internalReservation: false })
                 .where('equipmentOutDatetime', '<=', now)
                 .where('equipmentInDatetime', '>=', now)
                 .whereNot({ status: Status.CANCELED }),
         )
         .orWhere((x) =>
             x
-                .where({ bookingType: BookingType.GIG })
+                .where({ bookingType: BookingType.GIG, internalReservation: false })
                 .where('usageStartDatetime', '<=', now)
                 .where('usageEndDatetime', '>=', now)
                 .whereNot({ status: Status.CANCELED }),

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -319,6 +319,10 @@ export const getDefaultLaborHourlyRate = (pricePlan: PricePlan, globalSettings: 
     return toIntOrUndefined(defaultLaborHourlyRate) ?? 0;
 };
 
+export const IsNotInternalReservation = (booking: { internalReservation: boolean }) => {
+    return !booking.internalReservation;
+};
+
 export const IsBookingActive = (booking: BookingViewModel) => {
     return booking.status === Status.BOOKED || (booking.status === Status.DRAFT && booking.usageStartDatetime);
 };
@@ -330,10 +334,6 @@ export const IsBookingDraftOrBooked = (booking: BookingViewModel) => {
 export const IsBookingOut = (booking: BookingViewModel) => {
     if (!booking.equipmentLists) {
         throw new Error('Missing equipmentLists property');
-    }
-
-    if (booking.bookingType !== BookingType.RENTAL) {
-        return false;
     }
 
     return booking.equipmentLists?.some((x) => x.rentalStatus === RentalStatus.OUT);

--- a/src/models/interfaces/Booking.ts
+++ b/src/models/interfaces/Booking.ts
@@ -42,6 +42,7 @@ export interface Booking extends BaseEntityWithName {
     language: Language;
     fixedPrice: number | null;
     invoiceDate?: Date;
+    internalReservation: boolean;
 }
 
 export interface BookingViewModel extends Booking {

--- a/src/models/objection-models/BookingObjectionModel.ts
+++ b/src/models/objection-models/BookingObjectionModel.ts
@@ -48,6 +48,7 @@ export interface IBookingObjectionModel extends BaseObjectionModelWithName {
     language: Language;
     fixedPrice: number | null;
     invoiceDate: string | null;
+    internalReservation: boolean;
 }
 
 export class BookingObjectionModel extends Model {
@@ -166,6 +167,7 @@ export class BookingObjectionModel extends Model {
     language!: Language;
     fixedPrice!: number;
     invoiceDate!: string | null;
+    internalReservation!: boolean;
 }
 
 export interface IEquipmentListObjectionModel extends BaseObjectionModelWithName {

--- a/src/pages/api/external/v1/analytics/bookings.ts
+++ b/src/pages/api/external/v1/analytics/bookings.ts
@@ -23,6 +23,7 @@ import {
     getPricePlanName,
     getSalaryStatusName,
     getStatusName,
+    IsNotInternalReservation,
 } from '../../../../../lib/utils';
 
 const handler = withApiKeyContext(async (req: NextApiRequest, res: NextApiResponse): Promise<void> => {
@@ -31,6 +32,7 @@ const handler = withApiKeyContext(async (req: NextApiRequest, res: NextApiRespon
             await fetchBookings()
                 .then((x) => x.map(toBooking))
                 .then((x) => x.map(toBookingViewModel))
+                .then((x) => x.filter(IsNotInternalReservation))
                 .then((x) => mapToAnalytics(x))
                 .then((x) => mapToCSV(x))
                 .then((result) => res.status(200).setHeader('Content-Type', 'text/csv').send(result))

--- a/src/pages/api/external/v1/analytics/equipmentUsage.ts
+++ b/src/pages/api/external/v1/analytics/equipmentUsage.ts
@@ -18,6 +18,7 @@ import {
     getOperationalYear,
     getPricePlanName,
     getStatusName,
+    IsNotInternalReservation,
 } from '../../../../../lib/utils';
 import { AccountKind } from '../../../../../models/enums/AccountKind';
 import { fetchSettings } from '../../../../../lib/db-access/setting';
@@ -38,6 +39,7 @@ const handler = withApiKeyContext(async (req: NextApiRequest, res: NextApiRespon
             await fetchBookingsForAnalytics()
                 .then((x) => x.map(toBooking))
                 .then((x) => x.map(toBookingViewModel))
+                .then((x) => x.filter(IsNotInternalReservation))
                 .then((x) => mapToAnalytics(x, defaultEquipmentAccountExternal, defaultEquipmentAccountInternal))
                 .then((x) => mapToCSV(x))
                 .then((result) => res.status(200).setHeader('Content-Type', 'text/csv').send(result))

--- a/src/pages/api/external/v1/analytics/timeReports.ts
+++ b/src/pages/api/external/v1/analytics/timeReports.ts
@@ -15,6 +15,7 @@ import {
     getOperationalYear,
     getPricePlanName,
     getStatusName,
+    IsNotInternalReservation,
 } from '../../../../../lib/utils';
 import { AccountKind } from '../../../../../models/enums/AccountKind';
 import { fetchSettings } from '../../../../../lib/db-access/setting';
@@ -39,6 +40,7 @@ const handler = withApiKeyContext(async (req: NextApiRequest, res: NextApiRespon
             await fetchBookingsForAnalytics()
                 .then((x) => x.map(toBooking))
                 .then((x) => x.map(toBookingViewModel))
+                .then((x) => x.filter(IsNotInternalReservation))
                 .then((x) =>
                     mapToAnalytics(
                         x,

--- a/src/pages/api/external/v1/rentalsToHandleToday.ts
+++ b/src/pages/api/external/v1/rentalsToHandleToday.ts
@@ -6,7 +6,7 @@ import { Status } from '../../../../models/enums/Status';
 import { getEquipmentInDatetime, getEquipmentOutDatetime, HasDatetimes } from '../../../../lib/datetimeUtils';
 import { toBooking } from '../../../../lib/mappers/booking';
 import { EquipmentList } from '../../../../models/interfaces/EquipmentList';
-import { reduceSumFn } from '../../../../lib/utils';
+import { IsNotInternalReservation, reduceSumFn } from '../../../../lib/utils';
 import { BookingObjectionModel } from '../../../../models/objection-models';
 import { BookingType } from '../../../../models/enums/BookingType';
 
@@ -30,6 +30,7 @@ const getRentalsToHandleTodayFromBookings = (
     return result
         .filter((booking) => booking.status !== Status.CANCELED)
         .filter((booking) => booking.bookingType === BookingType.RENTAL)
+        .filter(IsNotInternalReservation)
         .map(toBooking)
         .map((booking) => ({
             name: booking.name,
@@ -50,7 +51,7 @@ const numberOfEquipment = (equipmentList: EquipmentList): number => {
     return allEquipmentEntries.map((x) => x.numberOfUnits).reduce(reduceSumFn);
 };
 
-const getLinkToBooking = (bookingId: number): string => (process.env.APPLICATION_BASE_URL + '/bookings/' + bookingId)
+const getLinkToBooking = (bookingId: number): string => process.env.APPLICATION_BASE_URL + '/bookings/' + bookingId;
 
 const handler = withApiKeyContext(async (req: NextApiRequest, res: NextApiResponse): Promise<void> => {
     switch (req.method) {

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -12,6 +12,7 @@ import {
     IsBookingDraftOrBooked,
     IsBookingOut,
     IsBookingUpcomingRental,
+    IsNotInternalReservation,
     onlyUniqueById,
 } from '../lib/utils';
 import { formatDatetime, toBookingViewModel } from '../lib/datetimeUtils';
@@ -37,8 +38,11 @@ const IndexPage: React.FC<Props> = ({ user: currentUser, globalSettings }: Props
     );
 
     const myDraftOrBookedBookings = myBookings?.map(toBookingViewModel).filter(IsBookingDraftOrBooked);
-    const upcomingRentalBookings = bookings?.map(toBookingViewModel).filter(IsBookingUpcomingRental);
-    const outBookings = bookings?.map(toBookingViewModel).filter(IsBookingOut);
+    const upcomingRentalBookings = bookings
+        ?.map(toBookingViewModel)
+        .filter(IsBookingUpcomingRental)
+        .filter(IsNotInternalReservation);
+    const outBookings = bookings?.map(toBookingViewModel).filter(IsBookingOut).filter(IsNotInternalReservation);
 
     const changelog = [...(myBookings ?? []), ...(coOwnerBookings ?? [])]
         .filter(onlyUniqueById)

--- a/src/pages/statistics.tsx
+++ b/src/pages/statistics.tsx
@@ -6,7 +6,15 @@ import { useUserWithDefaultAccessAndWithSettings } from '../lib/useUser';
 import { CurrentUserInfo } from '../models/misc/CurrentUserInfo';
 import { Card, Form, Nav, Tab } from 'react-bootstrap';
 import { bookingsFetcher } from '../lib/fetchers';
-import { getOperationalYear, getStatusName, groupBy, notEmpty, onlyUniqueById, reduceSumFn } from '../lib/utils';
+import {
+    getOperationalYear,
+    getStatusName,
+    groupBy,
+    IsNotInternalReservation,
+    notEmpty,
+    onlyUniqueById,
+    reduceSumFn,
+} from '../lib/utils';
 import { TableLoadingPage } from '../components/layout/LoadingPageSkeleton';
 import { ErrorPage } from '../components/layout/ErrorPage';
 import { TableConfiguration, TableDisplay } from '../components/TableDisplay';
@@ -239,6 +247,7 @@ const StatisticsPage: React.FC<Props> = ({ user: currentUser, globalSettings }: 
 
     const bookingsViewModels = bookings
         ?.map(toBookingViewModel)
+        ?.filter(IsNotInternalReservation)
         ?.filter((b) => b.usageStartDatetime)
         ?.filter((b) => includeFixedPriceZero || b.fixedPrice !== 0)
         ?.filter((booking: BookingViewModel) => statuses.length === 0 || statuses.indexOf(booking.status) >= 0);


### PR DESCRIPTION
Add internalReservation bool to booking object. When set, the booking is excluded from statistics, analytics, and the list of out rentals/equipment on the home page.

This is to support bookings which represent equipment permanently mounted, under reparation or otherwise unavailable for normal operation. As such, it enables users to use the conflict detection feature of a booking without messing up other parts of the system (i.e. the statistics/analytics).

I have debated whether or not to implement this as a bool or as a new Booking Type (alongside Gigs and Rentals), but in the end I decided to follow the meeting suggestion with a bool. In my option this is slightly worse from a data modeling perspective, but it greatly reduces user confusion as well as the risk of this feature being used unintentionally. If "Intern reservation" were available as a booking type I suspect there would be a lot of fixed-price-zero equipment usages which would end up under that category.

![image](https://github.com/user-attachments/assets/23c6d559-93f9-42da-9c97-ad19163d3cc2)
![image](https://github.com/user-attachments/assets/ac03dceb-f7fa-4b39-9e86-ea6d6b68a3a8)
![image](https://github.com/user-attachments/assets/15b7fd5e-e17f-448e-8701-6ffbba30c259)

If the checkbox is checked the booking is excluded from:
* Statistics
* Analytics endpoints
* Rentals To Handle Today endpoint (aka "Hyresbarbaren")
* "Kommande hyror", "Utlämnade hyror" and "Utlämnad utrustning" on the home page

The booking is still shown in:
* List of active bookings
* Booking archive
* Admin booking list
* "Mina bokningar", "Mina favoritbokningar", and "Aktivitet" on the home page