### PR TITLE
Feature: Improve performance by only fetching active bookings

### DIFF
--- a/src/lib/db-access/booking.ts
+++ b/src/lib/db-access/booking.ts
@@ -40,15 +40,21 @@ export const searchBookings = async (searchString: string, count: number): Promi
         .limit(count);
 };
 
-export const fetchBookings = async (): Promise<BookingObjectionModel[]> => {
+export const fetchBookings = async (excludeDoneAndCancelledBookings = false): Promise<BookingObjectionModel[]> => {
     ensureDatabaseIsInitialized();
 
-    return BookingObjectionModel.query()
+    let query = BookingObjectionModel.query()
         .withGraphFetched('ownerUser')
         .withGraphFetched('timeEstimates')
         .withGraphFetched('timeReports.user')
         .withGraphFetched('equipmentLists.listEntries.equipment')
         .withGraphFetched('equipmentLists.listHeadings.listEntries.equipment');
+
+    if (excludeDoneAndCancelledBookings) {
+        query = query.where('status', '<>', Status.DONE).where('status', '<>', Status.DONE);
+    }
+
+    return query;
 };
 
 export const fetchBookingsForAnalytics = async (): Promise<BookingObjectionModel[]> => {

--- a/src/lib/db-access/booking.ts
+++ b/src/lib/db-access/booking.ts
@@ -40,6 +40,8 @@ export const searchBookings = async (searchString: string, count: number): Promi
         .limit(count);
 };
 
+export const fetchActiveBookings = async () => fetchBookings(true);
+
 export const fetchBookings = async (excludeDoneAndCancelledBookings = false): Promise<BookingObjectionModel[]> => {
     ensureDatabaseIsInitialized();
 

--- a/src/lib/db-access/booking.ts
+++ b/src/lib/db-access/booking.ts
@@ -51,7 +51,7 @@ export const fetchBookings = async (excludeDoneAndCancelledBookings = false): Pr
         .withGraphFetched('equipmentLists.listHeadings.listEntries.equipment');
 
     if (excludeDoneAndCancelledBookings) {
-        query = query.where('status', '<>', Status.DONE).where('status', '<>', Status.DONE);
+        query = query.where('status', '<>', Status.DONE).andWhere('status', '<>', Status.CANCELED);
     }
 
     return query;

--- a/src/pages/api/bookings/active.ts
+++ b/src/pages/api/bookings/active.ts
@@ -1,0 +1,20 @@
+import { NextApiRequest, NextApiResponse } from 'next';
+import { respondWithCustomErrorMessage, respondWithInvalidMethodResponse } from '../../../lib/apiResponses';
+import { fetchBookings } from '../../../lib/db-access';
+import { withSessionContext } from '../../../lib/sessionContext';
+
+const handler = withSessionContext(async (req: NextApiRequest, res: NextApiResponse): Promise<void> => {
+    switch (req.method) {
+        case 'GET':
+            await fetchBookings(true)
+                .then((result) => res.status(200).json(result))
+                .catch((error) => respondWithCustomErrorMessage(res, error.message));
+            break;
+
+        default:
+            respondWithInvalidMethodResponse(res);
+    }
+    return;
+});
+
+export default handler;

--- a/src/pages/api/bookings/active.ts
+++ b/src/pages/api/bookings/active.ts
@@ -1,12 +1,12 @@
 import { NextApiRequest, NextApiResponse } from 'next';
 import { respondWithCustomErrorMessage, respondWithInvalidMethodResponse } from '../../../lib/apiResponses';
-import { fetchBookings } from '../../../lib/db-access';
 import { withSessionContext } from '../../../lib/sessionContext';
+import { fetchActiveBookings } from '../../../lib/db-access/booking';
 
 const handler = withSessionContext(async (req: NextApiRequest, res: NextApiResponse): Promise<void> => {
     switch (req.method) {
         case 'GET':
-            await fetchBookings(true)
+            await fetchActiveBookings()
                 .then((result) => res.status(200).json(result))
                 .catch((error) => respondWithCustomErrorMessage(res, error.message));
             break;

--- a/src/pages/bookings/index.tsx
+++ b/src/pages/bookings/index.tsx
@@ -24,7 +24,7 @@ const pageTitle = 'Aktiva bokningar';
 const breadcrumbs = [{ link: 'bookings', displayName: pageTitle }];
 
 const BookingListPage: React.FC<Props> = ({ user: currentUser, globalSettings }: Props) => {
-    const { data: bookings, error } = useSwr('/api/bookings', bookingsFetcher);
+    const { data: bookings, error } = useSwr('/api/bookings/active', bookingsFetcher);
 
     if (error) {
         return (

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -32,7 +32,7 @@ export const getServerSideProps = useUserWithDefaultAccessAndWithSettings();
 type Props = { user: CurrentUserInfo; globalSettings: KeyValue[] };
 
 const IndexPage: React.FC<Props> = ({ user: currentUser, globalSettings }: Props) => {
-    const { data: bookings } = useSwr('/api/bookings', bookingsFetcher);
+    const { data: bookings } = useSwr('/api/bookings/active', bookingsFetcher);
     const { data: myBookings } = useSwr('/api/users/' + currentUser.userId + '/bookings', bookingsFetcher);
     const { data: coOwnerBookings, mutate: mutateCoOwnerBookings } = useSwr(
         '/api/users/' + currentUser.userId + '/coOwnerBookings',


### PR DESCRIPTION
Previously all bookings (regardless of status, time, or other criteria) where always fetched for the front page and all lists of bookings. This made the front-page lists of upcoming rentals, out rentals, etc needlessly slow. By limiting these booking-list requests to only drafts and booked bookings (aka not done or cancelled) we can drastically reduce the payload size and the database read.

In my testing (with a copy of the production database from july) this reduces the load time from about 500ms to about a 100ms, so it loads (and feels) much faster. The number of bookings is reduced from about 800 to about 60, which further improves rendering speed etc.

In practice, this should have no impact on the results show (in theory there is a rare cases where done or cancelled bookings have equipment out - but in practice that does not happen).

The list of all bookings, admin overview, copy-equipment-list-from-booking list, etc are not included in this change and will continue to load all bookings as it is necessary for those features (or at lease more sophisticated filtering would be needed).