### PR TITLE
Bugfix: Handle equipment with no prices in price selection logic

### DIFF
--- a/src/components/bookings/equipmentLists/EditEquipmentListEntryModal.tsx
+++ b/src/components/bookings/equipmentLists/EditEquipmentListEntryModal.tsx
@@ -20,7 +20,7 @@ type Props = {
     getEquipmentListEntryPrices: (equipmentPrice: EquipmentPrice) => {
         pricePerHour: currency;
         pricePerUnit: currency;
-        equipmentPrice: EquipmentPrice;
+        equipmentPrice: EquipmentPrice | null;
     };
     equipmentListEntryToEditViewModel: Partial<EquipmentListEntry> | null;
     setEquipmentListEntryToEditViewModel: React.Dispatch<React.SetStateAction<Partial<EquipmentListEntry> | null>>;

--- a/src/components/bookings/equipmentLists/EquipmentListTable.tsx
+++ b/src/components/bookings/equipmentLists/EquipmentListTable.tsx
@@ -736,13 +736,17 @@ const EquipmentListTable: React.FC<Props> = ({
                             // Number of hours are shown if and only if there is a price per hour.
                             // Number of units are shown if there is no price per hour, or if there is both a price per hour and price per unit and the number of units in our inventory is larger than 1.
                             showNumberOfUnits={
-                                (!!getEquipmentListEntryPrices(getDefaultSelectedPrice(equipmentToAdd.prices), pricePlan).pricePerUnit
-                                    .value &&
+                                (!!getEquipmentListEntryPrices(
+                                    getDefaultSelectedPrice(equipmentToAdd.prices),
+                                    pricePlan,
+                                ).pricePerUnit.value &&
                                     equipmentToAdd.inventoryCount != 1) ||
-                                !getEquipmentListEntryPrices(getDefaultSelectedPrice(equipmentToAdd.prices), pricePlan).pricePerHour.value
+                                !getEquipmentListEntryPrices(getDefaultSelectedPrice(equipmentToAdd.prices), pricePlan)
+                                    .pricePerHour.value
                             }
                             showNumberOfHours={
-                                !!getEquipmentListEntryPrices(getDefaultSelectedPrice(equipmentToAdd.prices), pricePlan).pricePerHour.value
+                                !!getEquipmentListEntryPrices(getDefaultSelectedPrice(equipmentToAdd.prices), pricePlan)
+                                    .pricePerHour.value
                             }
                             title={language === Language.SV ? equipmentToAdd.name : equipmentToAdd.nameEN}
                             equipment={equipmentToAdd}

--- a/src/components/bookings/equipmentLists/SelectNumberOfUnitsAndHoursModal.tsx
+++ b/src/components/bookings/equipmentLists/SelectNumberOfUnitsAndHoursModal.tsx
@@ -39,7 +39,9 @@ const SelectNumberOfUnitsAndHoursModal: React.FC<Props> = ({
 }: Props) => {
     const [numberOfUnits, setNumberOfUnits] = useState<string>('1');
     const [numberOfHours, setNumberOfHours] = useState<string>(showNumberOfHours ? '1' : '0');
-    const [selectedPriceId, setSelectedPriceId] = useState<number>(getDefaultSelectedPrice(equipment.prices).id);
+    const [selectedPriceId, setSelectedPriceId] = useState<number | undefined>(
+        getDefaultSelectedPrice(equipment.prices)?.id,
+    );
 
     const numberOfUnitsRef = useRef<HTMLInputElement>(null);
     const numberOfHoursRef = useRef<HTMLInputElement>(null);

--- a/src/lib/equipmentListUtils.ts
+++ b/src/lib/equipmentListUtils.ts
@@ -108,12 +108,14 @@ export const getEquipmentFromViewModel = (viewModel: EquipmentListEntityViewMode
 // Heper functions to get default values
 //
 
-export const getEquipmentListEntryPrices = (equipmentPrice: EquipmentPrice, pricePlan: PricePlan) => {
+export const getEquipmentListEntryPrices = (equipmentPrice: EquipmentPrice | null, pricePlan: PricePlan) => {
     return {
         pricePerHour:
-            (pricePlan === PricePlan.EXTERNAL ? equipmentPrice?.pricePerHour : equipmentPrice?.pricePerHourTHS) ?? 0,
+            (pricePlan === PricePlan.EXTERNAL ? equipmentPrice?.pricePerHour : equipmentPrice?.pricePerHourTHS) ??
+            currency(0),
         pricePerUnit:
-            (pricePlan === PricePlan.EXTERNAL ? equipmentPrice?.pricePerUnit : equipmentPrice?.pricePerUnitTHS) ?? 0,
+            (pricePlan === PricePlan.EXTERNAL ? equipmentPrice?.pricePerUnit : equipmentPrice?.pricePerUnitTHS) ??
+            currency(0),
         equipmentPrice: equipmentPrice,
     };
 };
@@ -133,7 +135,8 @@ export const getDefaultListEntryFromEquipment = (
         throw new Error('Invalid equipment');
     }
 
-    const selectedPrice = equipment.prices.find((price) => price.id === selectedPriceId) ?? getDefaultSelectedPrice(equipment.prices);
+    const selectedPrice =
+        equipment.prices.find((price) => price.id === selectedPriceId) ?? getDefaultSelectedPrice(equipment.prices);
 
     const prices = isFree
         ? { pricePerHour: currency(0), pricePerUnit: currency(0) }
@@ -668,6 +671,10 @@ export const addTimeReportApiCall = async (timeReport: ITimeReportObjectionModel
         .then(toTimeReport);
 };
 
-export const getDefaultSelectedPrice = (prices: EquipmentPrice[]): EquipmentPrice => {
+export const getDefaultSelectedPrice = (prices: EquipmentPrice[]): EquipmentPrice | null => {
+    if (prices.length === 0) {
+        return null;
+    }
+
     return prices.reduce((minIdPrice, currentPrice) => (currentPrice.id < minIdPrice.id ? currentPrice : minIdPrice));
 };

--- a/src/pages/public/prices.tsx
+++ b/src/pages/public/prices.tsx
@@ -189,11 +189,11 @@ const PublicPricePage: React.FC<Props> = ({ equipment, equipmentCategories, glob
                                                     ))}
                                                 </div>
                                             </td>
-                                            {equipment.prices ? (
+                                            {equipment.prices && equipment.prices.length > 0 ? (
                                                 <PriceCells
-                                                    price={getDefaultSelectedPrice(
-                                                        equipment.prices.map(toEquipmentPrice),
-                                                    )}
+                                                    price={
+                                                        getDefaultSelectedPrice(equipment.prices.map(toEquipmentPrice))!
+                                                    }
                                                     hidePriceType={equipment.prices.length === 1}
                                                     showWithVat={includeVat}
                                                     showThsPrice={showThsPrice}


### PR DESCRIPTION
Handle equipment with no prices in price selection logic to avoid crash.

Most of this PR is just type changes to reflect the new logic - the actual fix is these lines:
```
    if (prices.length === 0) {
        return null;
    }
```

Additionally, I also adjusted `CopyEquipmentListEntriesModal `to use the price selection function from `equipmentListUtils`.