### PR TITLE
Feature: Handle '/' in calendar name-tag list

### DIFF
--- a/src/lib/calenderUtils.ts
+++ b/src/lib/calenderUtils.ts
@@ -12,7 +12,7 @@ const getNameTagsFromEventName = (name: string): string[] => {
     const match = name.match(/\[(.*?)\]/);
     if (match) {
         return match[1]
-            .split(',')
+            .split(/[,/]/)
             .map((x) => (x.includes(':') ? x.split(':')[1] : x))
             .map((x) => x.trim());
     }


### PR DESCRIPTION
If the calendar name tag list looks like `'[AA, BB/CC, DD]'` we now split on the `'/'` try to find users `BB` and `CC` instead of a user `BB/CC`.