### PR TITLE
Bugfix; Fix time report sorting on start time

### DIFF
--- a/src/components/bookings/timeReport/TimeReportList.tsx
+++ b/src/components/bookings/timeReport/TimeReportList.tsx
@@ -34,7 +34,7 @@ import {
     moveItemUp,
     sortIndexSortFn,
 } from '../../../lib/sortIndexUtils';
-import { formatDatetime, toBookingViewModel } from '../../../lib/datetimeUtils';
+import { formatDateForForm, formatDatetime, toBookingViewModel } from '../../../lib/datetimeUtils';
 import TimeReportAddButton from './TimeReportAddButton';
 import TimeReportModal from './TimeReportModal';
 import { addTimeReportApiCall } from '../../../lib/equipmentListUtils';
@@ -332,7 +332,7 @@ const TimeReportList: React.FC<Props> = ({ bookingId, currentUser, readonly, def
                 key: 'specification',
                 displayName: 'Beskrivning',
                 getValue: (timeReport: TimeReport) =>
-                    timeReport.startDatetime ? formatDatetime(timeReport.startDatetime) : '-',
+                    timeReport.startDatetime ? formatDateForForm(timeReport.startDatetime) : '-',
                 getContentOverride: TimeReportSpecificationDisplayFn,
             },
             {


### PR DESCRIPTION
On the booking page the time report table "Beskrivning" which contains both the description and time of the report is supposed to sort on the start time. Previously it did this by using the "formatDatetime" function which formats the date with the weekday spell out, resulting in a sorting by weekday alphabetically.

This PR corrects this by changing to an ISO format resulting in the correct sorting.

---

Note: This behavior is kind of hidden which is not ideal, so in the future it might be good to discuss whether we should rename the column and/or change the display function so the time is shown above the description. However, I wanted to fix the current implementation before changing the behavior.