### PR TITLE
Feature: Add placeholders in forms for creating time estimates and reports

### DIFF
--- a/src/components/bookings/timeEstimate/TimeEstimateModal.tsx
+++ b/src/components/bookings/timeEstimate/TimeEstimateModal.tsx
@@ -175,6 +175,7 @@ const TimeEstimateModal: React.FC<Props> = ({
                                 <Form.Control
                                     type="text"
                                     required
+                                    placeholder="2 tekniker (18:00-03:00)"
                                     readOnly={readonly}
                                     value={timeEstimate?.name}
                                     onChange={(e) =>
@@ -197,6 +198,7 @@ const TimeEstimateModal: React.FC<Props> = ({
                                         required
                                         value={timeEstimate?.numberOfHours}
                                         type="text"
+                                        placeholder="18"
                                         readOnly={readonly}
                                         onChange={(e) =>
                                             setTimeEstimate({

--- a/src/components/bookings/timeReport/TimeReportModal.tsx
+++ b/src/components/bookings/timeReport/TimeReportModal.tsx
@@ -92,6 +92,7 @@ const TimeReportModal: React.FC<Props> = ({
                                     type="text"
                                     required
                                     defaultValue={timeReport?.name}
+                                    placeholder="Upprigg torsdag"
                                     readOnly={readonly}
                                     onChange={(e) =>
                                         setTimeReport({


### PR DESCRIPTION
Add placeholders in forms for creating time estimates and reports to make it easier to understand the expected values

<img width="933" height="428" alt="image" src="https://github.com/user-attachments/assets/5918d1a1-42b6-4c7a-9cb5-915c1182dc49" />
<img width="832" height="523" alt="image" src="https://github.com/user-attachments/assets/72ea1e29-cc08-420e-a216-c869a5c15a32" />
