### PR TITLE
Feature: Custom document export

### DIFF
--- a/src/document-templates/index.tsx
+++ b/src/document-templates/index.tsx
@@ -1,7 +1,7 @@
 import React, { ReactElement } from 'react';
 import { PriceEstimateDocument } from './components/priceEstimateDocument';
 import { Booking } from '../models/interfaces';
-import { getTextResourcesFromGlobalSettings, registerFonts } from './utils';
+import { getTextResourcesFromGlobalSettings, overrideTranslations, registerFonts } from './utils';
 import { getTextResource, TextResourcesContext } from './useTextResources';
 import { PackingListDocument } from './components/packingListDocument';
 import { Language } from '../models/enums/Language';
@@ -21,9 +21,16 @@ export const getPriceEstimateDocument = (
     booking: Booking,
     documentLanguage: Language,
     globalSettings: KeyValue[],
+    textResourcesOverrides: Record<string, string> = {},
 ): ReactElement => (
     <TextResourcesContext.Provider
-        value={{ language: documentLanguage, textResources: getTextResourcesFromGlobalSettings(globalSettings) }}
+        value={{
+            language: documentLanguage,
+            textResources: overrideTranslations(
+                getTextResourcesFromGlobalSettings(globalSettings),
+                textResourcesOverrides,
+            ),
+        }}
     >
         <PriceEstimateDocument booking={booking} globalSettings={globalSettings} />
     </TextResourcesContext.Provider>
@@ -33,11 +40,12 @@ export const getPriceEstimateDocumentFileName = (
     booking: Booking,
     documentLanguage: Language,
     globalSettings: KeyValue[],
+    textResourcesOverrides: Record<string, string> = {},
 ): string => {
     const prefix = getTextResource(
         'price-estimate.filename',
         documentLanguage,
-        getTextResourcesFromGlobalSettings(globalSettings),
+        overrideTranslations(getTextResourcesFromGlobalSettings(globalSettings), textResourcesOverrides),
     );
 
     const date = toBookingViewModel(booking).usageStartDatetime;
@@ -57,9 +65,16 @@ export const getPackingListDocument = (
     documentLanguage: Language,
     globalSettings: KeyValue[],
     equipmentListId?: number,
+    textResourcesOverrides: Record<string, string> = {},
 ): ReactElement => (
     <TextResourcesContext.Provider
-        value={{ language: documentLanguage, textResources: getTextResourcesFromGlobalSettings(globalSettings) }}
+        value={{
+            language: documentLanguage,
+            textResources: overrideTranslations(
+                getTextResourcesFromGlobalSettings(globalSettings),
+                textResourcesOverrides,
+            ),
+        }}
     >
         <PackingListDocument booking={booking} globalSettings={globalSettings} equipmentListId={equipmentListId} />
     </TextResourcesContext.Provider>
@@ -69,11 +84,12 @@ export const getPackingListDocumentFileName = (
     booking: Booking,
     documentLanguage: Language,
     globalSettings: KeyValue[],
+    textResourcesOverrides: Record<string, string> = {},
 ): string =>
     `${getTextResource(
         'packing-list.filename',
         documentLanguage,
-        getTextResourcesFromGlobalSettings(globalSettings),
+        overrideTranslations(getTextResourcesFromGlobalSettings(globalSettings), textResourcesOverrides),
     )} ${booking.name}.pdf`;
 
 // Rental Confirmation
@@ -82,9 +98,16 @@ export const getRentalConfirmationDocument = (
     booking: Booking,
     documentLanguage: Language,
     globalSettings: KeyValue[],
+    textResourcesOverrides: Record<string, string> = {},
 ): ReactElement => (
     <TextResourcesContext.Provider
-        value={{ language: documentLanguage, textResources: getTextResourcesFromGlobalSettings(globalSettings) }}
+        value={{
+            language: documentLanguage,
+            textResources: overrideTranslations(
+                getTextResourcesFromGlobalSettings(globalSettings),
+                textResourcesOverrides,
+            ),
+        }}
     >
         <RentalConfirmationDocument booking={booking} globalSettings={globalSettings} />
     </TextResourcesContext.Provider>
@@ -94,11 +117,12 @@ export const getRentalConfirmationDocumentFileName = (
     booking: Booking,
     documentLanguage: Language,
     globalSettings: KeyValue[],
+    textResourcesOverrides: Record<string, string> = {},
 ): string =>
     `${getTextResource(
         'rental-agreement.filename',
         documentLanguage,
-        getTextResourcesFromGlobalSettings(globalSettings),
+        overrideTranslations(getTextResourcesFromGlobalSettings(globalSettings), textResourcesOverrides),
     )} ${booking.name}.pdf`;
 
 // Salary Report (no language support)
@@ -115,9 +139,16 @@ export const getInvoiceDocument = (
     invoiceData: InvoiceData,
     documentLanguage: Language,
     globalSettings: KeyValue[],
+    textResourcesOverrides: Record<string, string> = {},
 ): ReactElement => (
     <TextResourcesContext.Provider
-        value={{ language: documentLanguage, textResources: getTextResourcesFromGlobalSettings(globalSettings) }}
+        value={{
+            language: documentLanguage,
+            textResources: overrideTranslations(
+                getTextResourcesFromGlobalSettings(globalSettings),
+                textResourcesOverrides,
+            ),
+        }}
     >
         <InvoiceDocument invoiceData={invoiceData} globalSettings={globalSettings} />
     </TextResourcesContext.Provider>

--- a/src/pages/bookings/[id]/custom-document-export.tsx
+++ b/src/pages/bookings/[id]/custom-document-export.tsx
@@ -1,0 +1,137 @@
+import React, { useEffect, useState } from 'react';
+import Layout from '../../../components/layout/Layout';
+import useSwr from 'swr';
+import { useRouter } from 'next/router';
+import { Button, Card, Col, Form, Row } from 'react-bootstrap';
+import { CurrentUserInfo } from '../../../models/misc/CurrentUserInfo';
+import { useUserWithDefaultAccessAndWithSettings } from '../../../lib/useUser';
+import { bookingFetcher } from '../../../lib/fetchers';
+import Header from '../../../components/layout/Header';
+import { TwoColLoadingPage } from '../../../components/layout/LoadingPageSkeleton';
+import { ErrorPage } from '../../../components/layout/ErrorPage';
+import { Role } from '../../../models/enums/Role';
+import { faSave } from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { KeyValue } from '../../../models/interfaces/KeyValue';
+
+// eslint-disable-next-line react-hooks/rules-of-hooks
+export const getServerSideProps = useUserWithDefaultAccessAndWithSettings(Role.USER);
+type Props = { user: CurrentUserInfo; globalSettings: KeyValue[] };
+
+const BookingPage: React.FC<Props> = ({ user: currentUser, globalSettings }: Props) => {
+    const [title, setTitle] = useState('Dokument');
+    const [legalTitle, setLegalTitle] = useState('Titel');
+    const [legalContent, setLegalContent] = useState('Innehåll');
+    const [showLegalLink, setShowLegalLink] = useState(true);
+    const [debouncedUrl, setDebouncedUrl] = useState('');
+
+    const router = useRouter();
+    const {
+        data: booking,
+        error,
+        isValidating,
+    } = useSwr('/api/bookings/' + router.query.id, bookingFetcher, {
+        revalidateOnFocus: false,
+        revalidateOnReconnect: false,
+    });
+
+    
+
+    useEffect(() => {
+        const getDocumentUrl = () =>
+            `/api/documents/price-estimate/${booking?.language}/${booking?.id}?override-price-estimate.title=${title}&override-price-estimate.legal-note.title=${legalTitle}&override-price-estimate.legal-note.content=${legalContent}` +
+            (showLegalLink ? '' : '&override-price-estimate.legal-note.shown-url=');
+
+        const handler = setTimeout(() => setDebouncedUrl(getDocumentUrl()), 500);
+    
+        return () => clearTimeout(handler);
+      }, [booking, title, legalTitle, legalContent, showLegalLink]);
+
+    if (error) {
+        return (
+            <ErrorPage
+                errorMessage={error.message}
+                fixedWidth={true}
+                currentUser={currentUser}
+                globalSettings={globalSettings}
+            />
+        );
+    }
+
+    if (isValidating || !booking) {
+        return <TwoColLoadingPage fixedWidth={true} currentUser={currentUser} globalSettings={globalSettings} />;
+    }
+
+    // The page itself
+    //
+    const pageTitle = booking?.name;
+    const breadcrumbs = [
+        { link: '/bookings', displayName: 'Bokningar' },
+        { link: '/bookings/' + booking.id, displayName: pageTitle },
+        { link: '/bookings/' + booking.id + '/custom-document-export', displayName: 'Anpassad dokumentexport' },
+    ];
+
+
+
+    return (
+        <Layout title={pageTitle} fixedWidth={false} currentUser={currentUser} globalSettings={globalSettings}>
+            <Header title={pageTitle} breadcrumbs={breadcrumbs}>
+                <Button variant="primary" href={debouncedUrl} target="_blank">
+                    <FontAwesomeIcon icon={faSave} className="mr-1" /> Exportera
+                </Button>
+            </Header>
+            <Row className="mb-3">
+                <Col xl={8}>
+                    <Form.Group>
+                        <Form.Label>Titel</Form.Label>
+
+                        <Form.Control type="text" defaultValue={title} onChange={(e) => setTitle(e.target.value)} />
+                    </Form.Group>
+
+                    <Form.Group>
+                        <Form.Label>Titel villkor</Form.Label>
+
+                        <Form.Control
+                            type="text"
+                            defaultValue={legalTitle}
+                            onChange={(e) => setLegalTitle(e.target.value)}
+                        />
+                    </Form.Group>
+
+                    <Form.Group>
+                        <Form.Label>Innehåll villkor</Form.Label>
+
+                        <Form.Control
+                            as="textarea"
+                            rows={6}
+                            defaultValue={legalContent}
+                            onChange={(e) => setLegalContent(e.target.value)}
+                        />
+                    </Form.Group>
+
+                    <Form.Group controlId="resetNames">
+                        <Form.Check
+                            type="checkbox"
+                            label="Visa länk till villkor"
+                            checked={showLegalLink}
+                            onChange={() => setShowLegalLink(!showLegalLink)}
+                        />
+                    </Form.Group>
+                </Col>
+                <Col xl={4}>
+                    <Card>
+                        <Card.Header>Förhandsgranskning</Card.Header>
+
+                        <Card.Body>
+                            <div className="w-full m-auto" style={{ maxWidth: '550px' }}>
+                                <embed src={debouncedUrl} type="application/pdf" width="100%" height="750" />
+                            </div>
+                        </Card.Body>
+                    </Card>
+                </Col>
+            </Row>
+        </Layout>
+    );
+};
+
+export default BookingPage;

--- a/src/pages/bookings/[id]/index.tsx
+++ b/src/pages/bookings/[id]/index.tsx
@@ -26,6 +26,7 @@ import {
     faCoins,
     faFileDownload,
     faFilePdf,
+    faFilePen,
     faFileText,
     faLock,
     faLockOpen,
@@ -248,6 +249,12 @@ const BookingPage: React.FC<Props> = ({ user: currentUser, globalSettings }: Pro
                                 <FontAwesomeIcon icon={faFileText} className="mr-1 fa-fw" /> Fakturaunderlag (Hogia
                                 import)
                             </Dropdown.Item>
+                            <Dropdown.Divider />
+                            <Link href={`/bookings/${booking.id}/custom-document-export`} passHref>
+                                <Dropdown.Item href={`/bookings/${booking.id}/custom-document-export`} target="_blank">
+                                    <FontAwesomeIcon icon={faFilePen} className="mr-1 fa-fw" /> Anpassad dokumentexport
+                                </Dropdown.Item>
+                            </Link>
                         </IfAdmin>
                     </Dropdown.Menu>
                 </Dropdown>


### PR DESCRIPTION
Add a page where admins can customize title and legal note of price export to create, for example, quotations.

One half of the PR is adding support in the document export urls for overriding texts. This supports all documents and text resources, just att a url parameter of 'override-{text-resource-key}' with the new translation as the value. Examples:

- `?override-price-estimate.title=Offert&override-price-estimate.legal-note.title=Giltighet&override-price-estimate.legal-note.content=1000 år` to create a quotation
- `?override-common.total-price-section.heading=Prisinformation` to change the text of the price summary to "Prisinformation" instead of "Sammanfattning"

Note: this is available to all users by just modifying the url, there is no access control.

The second half is a new interface only available to a admins. This allows admins to quickly change the title, change the legal section title, change the legal section content, and hide/show legal section link of price estimates. A preview is shown to the side. I suspect these will be the most commonly updated texts and hopefully cover a large majority of use cases, and for more advanced changes the user will have to manually modify the url in the browser (or edit the downloaded pdf).

Note: The overridden texts are not stored anywhere, nor is it stored that a quotation or any custom document is downloaded or the price used. I believe we send quotations far to rarely for any such features to make sense for now (and the amount of manual work of keeping track of quotations send is not that significant).

<img width="861" height="464" alt="image" src="https://github.com/user-attachments/assets/30c054f0-27c5-42ea-863f-ff87f9dae117" />

<img width="1743" height="917" alt="image" src="https://github.com/user-attachments/assets/a080fa46-3aa7-4883-a5a3-562884f1c853" />

<img width="715" height="984" alt="image" src="https://github.com/user-attachments/assets/40727977-d3db-48a5-9cd3-27732db2ed67" />
