### PR TITLE
Bugfix: Fix infinitive-loop-bug on in large booking table

### DIFF
--- a/src/components/LargeBookingTable.tsx
+++ b/src/components/LargeBookingTable.tsx
@@ -139,7 +139,7 @@ const LargeBookingTable: React.FC<Props> = ({ bookings, tableSettingsOverride, s
         setUserIds([]);
     }
     if (statuses.some((status) => !statusOptions.some((x) => x.value === status))) {
-        setUserIds([]);
+        setStatuses([]);
     }
 
     // Handlers for changed bookings


### PR DESCRIPTION
When adjusting the filtering of the tables we added safe-guards to protect against filter filtering on unavailable statuses, which reset the filters. Unfortunately the booking status safeguard reset the user filter, which re-renders the page - and since the booking statuses have not changed the same safeguard is triggered, resulting in an infinitive loop.

This PR adjusts the safe-guard to reset the correct filter.