### PR TITLE
Feature: move count column in equipment packing list

### DIFF
--- a/src/pages/bookings/[id]/equipmentList/[listId]/index.tsx
+++ b/src/pages/bookings/[id]/equipmentList/[listId]/index.tsx
@@ -149,6 +149,18 @@ const BookingPage: React.FC<Props> = ({ user: currentUser, globalSettings }: Pro
                 disableSort: true,
             },
             {
+                key: 'count',
+                displayName: 'Antal',
+                getValue: (entry: EquipmentListEntry) => entry.numberOfUnits ?? '-',
+                getContentOverride: (entry: EquipmentListEntry) =>
+                    entry.numberOfUnits === null ? '-' : entry.numberOfUnits + ' st',
+                getHeadingValue: (entry: EquipmentListEntry) =>
+                    entry.numberOfUnits === null ? '-' : entry.numberOfUnits + ' st',
+                textAlignment: 'center',
+                columnWidth: 120,
+                disableSort: true,
+            },
+            {
                 key: 'name',
                 displayName: 'Utrustning',
                 getValue: (entry: EquipmentListEntry) => entry.name + ' ' + entry.description,
@@ -164,18 +176,6 @@ const BookingPage: React.FC<Props> = ({ user: currentUser, globalSettings }: Pro
                     entry.equipment?.equipmentLocation?.name ?? 'Okänd plats',
                 cellHideSize: 'xl',
                 columnWidth: 200,
-                disableSort: true,
-            },
-            {
-                key: 'count',
-                displayName: 'Antal',
-                getValue: (entry: EquipmentListEntry) => entry.numberOfUnits ?? '-',
-                getContentOverride: (entry: EquipmentListEntry) =>
-                    entry.numberOfUnits === null ? '-' : entry.numberOfUnits + ' st',
-                getHeadingValue: (entry: EquipmentListEntry) =>
-                    entry.numberOfUnits === null ? '-' : entry.numberOfUnits + ' st',
-                textAlignment: 'center',
-                columnWidth: 120,
                 disableSort: true,
             },
         ],


### PR DESCRIPTION
I find this easier to read, since I tend to have to look at the count column a bunch of times to double-check the value. Especially annoying on wider screens.

Looks like this:

<img width="1258" height="651" alt="2025-11-26-01:17:41" src="https://github.com/user-attachments/assets/935e0184-4835-4ac7-b552-db8e43253dbb" />
