### PR TITLE
Feature: Google Drive integration for equipment

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,9 @@ MAX_SESSION_LENGTH={Maximum number of milliseconds a user is allowed to stay log
 CALENDAR_API_KEY={Google Calender API Key, with read-access to calendars}
 CALENDAR_ID={Google Calender ID to fetch events from}
 
-DRIVE_CREDENTIALS={Base64 encoded Google Drive Service Account credentials in JSON format. The account should have write-access to DRIVE_ROOT_FOLDER}
-DRIVE_ROOT_FOLDER_ID={ID of folder which contains booking folders}
+DRIVE_CREDENTIALS={Base64 encoded Google Drive Service Account credentials in JSON format. The account should have write-access to both root folders}
+DRIVE_BOOKING_ROOT_FOLDER_ID={ID of folder which contains booking folders}
+DRIVE_EQUIPMENT_ROOT_FOLDER_ID={ID of folder which contains equipment folders}
 
 SLACK_BOT_TOKEN={API token for slack bot, with chat:write access}
 SLACK_CHANNEL_ID={Slack channel to post message to}

--- a/knex/migrations/20260402000000_equipment_drive_folder.js
+++ b/knex/migrations/20260402000000_equipment_drive_folder.js
@@ -1,0 +1,11 @@
+export function up(knex) {
+    return knex.schema.alterTable('Equipment', (table) => {
+        table.text('driveFolderId');
+    });
+}
+
+export function down(knex) {
+    return knex.schema.alterTable('Equipment', (table) => {
+        table.dropColumn('driveFolderId');
+    });
+}

--- a/src/components/FilesCard.tsx
+++ b/src/components/FilesCard.tsx
@@ -1,9 +1,9 @@
 import React, { useState } from 'react';
 import { Button, Card, ListGroup } from 'react-bootstrap';
-import { formatDatetimeForForm } from '../../lib/datetimeUtils';
+import { formatDatetimeForForm } from '../lib/datetimeUtils';
 import useSwr from 'swr';
-import { FilesResult } from '../../models/misc/FilesResult';
-import { getResponseContentOrError } from '../../lib/utils';
+import { FilesResult } from '../models/misc/FilesResult';
+import { getResponseContentOrError } from '../lib/utils';
 import {
     faAngleDown,
     faAngleUp,
@@ -19,16 +19,17 @@ import {
     faPlus,
 } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { getSortedList } from '../../lib/sortIndexUtils';
-import TableStyleLink from '../utils/TableStyleLink';
+import { getSortedList } from '../lib/sortIndexUtils';
+import TableStyleLink from './utils/TableStyleLink';
 import Skeleton from 'react-loading-skeleton';
-import { useNotifications } from '../../lib/useNotifications';
-import { getDriveLink } from '../../lib/db-access/utils';
+import { useNotifications } from '../lib/useNotifications';
+import { getDriveLink } from '../lib/db-access/utils';
 
 type Props = {
     driveFolderId: string;
     defaultFolderName: string;
-    defaultParentFolder: string;
+    defaultParentFolder?: string;
+    driveType: 'booking' | 'equipment';
     onSubmit: (driveFolderId: string) => void;
     readonly?: boolean;
 };
@@ -37,6 +38,7 @@ const FilesCard: React.FC<Props> = ({
     driveFolderId,
     defaultFolderName,
     defaultParentFolder,
+    driveType,
     onSubmit,
     readonly = false,
 }: Props) => {
@@ -45,12 +47,8 @@ const FilesCard: React.FC<Props> = ({
 
     const link = getDriveLink(driveFolderId);
 
-    const createFolder = async (name: string, parentName: string) => {
-        const body = {
-            name,
-            parentName,
-        };
-
+    const createFolder = async (name: string, parentName: string | undefined) => {
+        const body = { name, parentName, driveType };
         const request = {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },

--- a/src/components/equipment/EquipmentForm.tsx
+++ b/src/components/equipment/EquipmentForm.tsx
@@ -1,5 +1,5 @@
 import React, { FormEvent, useState } from 'react';
-import { Col, Form, Row } from 'react-bootstrap';
+import { Button, Col, Row, Form } from 'react-bootstrap';
 import { Typeahead } from 'react-bootstrap-typeahead';
 import { Equipment } from '../../models/interfaces';
 import type { EquipmentTag } from '../../models/interfaces';
@@ -23,6 +23,7 @@ const EquipmentForm: React.FC<Props> = ({ handleSubmitEquipment, equipment: equi
     const [validated, setValidated] = useState(false);
     const [selectedTags, setSelectedTags] = useState(equipment?.tags ?? []);
     const [prices, setPrices] = useState(equipment?.prices ?? []);
+    const [showAdvancedFields, setShowAdvancedFields] = useState(false);
 
     const { data: equipmentTags } = useSwr('/api/equipmentTags', equipmentTagsFetcher);
 
@@ -93,6 +94,7 @@ const EquipmentForm: React.FC<Props> = ({ handleSubmitEquipment, equipment: equi
             inventoryCount: toIntOrUndefined(getValueFromForm('inventoryCount')) ?? null,
             publiclyHidden: getValueFromForm('publiclyHidden') === 'true',
             note: getValueFromForm('note'),
+            driveFolderId: getValueFromForm('driveFolderId'),
         };
 
         handleSubmitEquipment(modifiedEquipment);
@@ -283,6 +285,38 @@ const EquipmentForm: React.FC<Props> = ({ handleSubmitEquipment, equipment: equi
                             </Form.Group>
                         </Col>
                     </Row>
+
+                    <div className="d-flex">
+                        <div className="flex-grow-1"></div>
+                        <div>
+                            <Button
+                                className="mb-3"
+                                variant="secondary"
+                                size="sm"
+                                onClick={() => setShowAdvancedFields((x) => !x)}
+                            >
+                                {showAdvancedFields ? 'Dölj' : 'Visa'} avancerade fält
+                            </Button>
+                        </div>
+                    </div>
+
+                    {showAdvancedFields ? (
+                        <Row>
+                            <Col lg="4" md="4">
+                                <Form.Group controlId="driveFolderId">
+                                    <Form.Label>Mapp-id</Form.Label>
+                                    <Form.Control
+                                        type="text"
+                                        placeholder=""
+                                        name="driveFolderId"
+                                        defaultValue={equipment?.driveFolderId}
+                                    />
+                                </Form.Group>
+                            </Col>
+                        </Row>
+                    ) : (
+                        <Form.Control type="hidden" name="driveFolderId" defaultValue={equipment?.driveFolderId} />
+                    )}
                 </>
             )}
         </Form>

--- a/src/models/interfaces/Equipment.ts
+++ b/src/models/interfaces/Equipment.ts
@@ -16,6 +16,7 @@ export interface Equipment extends BaseEntityWithName {
     image?: Image;
     publiclyHidden: boolean;
     isArchived: boolean;
+    driveFolderId: string;
     equipmentPublicCategory?: EquipmentPublicCategory;
     equipmentLocation?: EquipmentLocation;
     changelog: EquipmentChangelogEntry[];

--- a/src/models/objection-models/EquipmentObjectionModel.ts
+++ b/src/models/objection-models/EquipmentObjectionModel.ts
@@ -16,6 +16,7 @@ export interface IEquipmentObjectionModel extends BaseObjectionModelWithName {
     image: unknown; // TODO Add images
     publiclyHidden: boolean;
     isArchived: boolean;
+    driveFolderId: string;
     equipmentPublicCategoryId?: number | null;
     equipmentPublicCategory?: IEquipmentPublicCategoryObjectionModel;
     equipmentLocationId?: number | null;
@@ -88,6 +89,7 @@ export class EquipmentObjectionModel extends Model implements IEquipmentObjectio
     image!: unknown; // TODO Add images
     publiclyHidden!: boolean;
     isArchived!: boolean;
+    driveFolderId!: string;
 
     equipmentPublicCategoryId?: number;
     equipmentPublicCategory?: EquipmentPublicCategoryObjectionModel;

--- a/src/pages/api/files/index.ts
+++ b/src/pages/api/files/index.ts
@@ -12,7 +12,8 @@ import { getValueOrFirst } from '../../../lib/utils';
 
 const credentials = JSON.parse(Buffer.from(process.env.DRIVE_CREDENTIALS ?? '', 'base64').toString());
 const scopes = ['https://www.googleapis.com/auth/drive'];
-const driveRootFolderId = process.env.DRIVE_ROOT_FOLDER_ID;
+const driveBookingRootFolderId = process.env.DRIVE_BOOKING_ROOT_FOLDER_ID;
+const driveEquipmentRootFolderId = process.env.DRIVE_EQUIPMENT_ROOT_FOLDER_ID;
 
 const driveClient = drive({
     version: 'v3',
@@ -24,10 +25,17 @@ const handler = withSessionContext(async (req: NextApiRequest, res: NextApiRespo
 
     const name = req.body.name;
     const parentName = req.body.parentName;
+    const driveType: 'booking' | 'equipment' | undefined = req.body.driveType;
+    const driveRootFolderId =
+        driveType === 'equipment'
+            ? driveEquipmentRootFolderId
+            : driveType === 'booking'
+              ? driveBookingRootFolderId
+              : undefined;
 
     switch (req.method) {
         case 'GET':
-            if (!driveFolderId || !driveRootFolderId) {
+            if (!driveFolderId) {
                 respondWithInvalidDataResponse(res);
                 break;
             }
@@ -45,15 +53,21 @@ const handler = withSessionContext(async (req: NextApiRequest, res: NextApiRespo
             break;
 
         case 'POST':
-            if (!name || !parentName || !driveRootFolderId) {
+            if (!name || !driveType || !driveRootFolderId) {
                 respondWithInvalidDataResponse(res);
                 break;
             }
 
-            await createFolderAndGetIdIfNotExists(parentName, driveRootFolderId)
-                .then((parentId) => createFolderAndGetIdIfNotExists(name, parentId))
-                .then((filesList) => res.status(200).json(filesList))
-                .catch((error) => respondWithCustomErrorMessage(res, error.message));
+            if (parentName) {
+                await createFolderAndGetIdIfNotExists(parentName, driveRootFolderId)
+                    .then((parentId) => createFolderAndGetIdIfNotExists(name, parentId))
+                    .then((folderId) => res.status(200).json(folderId))
+                    .catch((error) => respondWithCustomErrorMessage(res, error.message));
+            } else {
+                await createFolderAndGetIdIfNotExists(name, driveRootFolderId)
+                    .then((folderId) => res.status(200).json(folderId))
+                    .catch((error) => respondWithCustomErrorMessage(res, error.message));
+            }
 
             break;
 

--- a/src/pages/bookings/[id]/index.tsx
+++ b/src/pages/bookings/[id]/index.tsx
@@ -55,7 +55,8 @@ import MarkdownCard from '../../../components/MarkdownCard';
 import ToggleCoOwnerButton from '../../../components/bookings/ToggleCoOwnerButton';
 import ConfirmModal from '../../../components/utils/ConfirmModal';
 import BookingInfoSection from '../../../components/bookings/BookingInfoSection';
-import FilesCard from '../../../components/bookings/FilesCard';
+import FilesCard from '../../../components/FilesCard';
+import currency from 'currency.js';
 import PreviousBookingsCard from '../../../components/bookings/PreviousBookingsCard';
 import { BookingType } from '../../../models/enums/BookingType';
 import CalendarWorkersCard from '../../../components/bookings/CalendarWorkersCard';
@@ -485,6 +486,7 @@ const BookingPage: React.FC<Props> = ({ user: currentUser, globalSettings }: Pro
                         driveFolderId={booking.driveFolderId}
                         defaultFolderName={`${formatDateForForm(booking.usageStartDatetime, 'N/A')} ${booking.name}`}
                         defaultParentFolder={getOperationalYear(booking.usageStartDatetime)}
+                        driveType="booking"
                         onSubmit={(driveFolderId) => saveBooking({ driveFolderId })}
                         readonly={readonly}
                     />

--- a/src/pages/bookings/[id]/index.tsx
+++ b/src/pages/bookings/[id]/index.tsx
@@ -56,7 +56,6 @@ import ToggleCoOwnerButton from '../../../components/bookings/ToggleCoOwnerButto
 import ConfirmModal from '../../../components/utils/ConfirmModal';
 import BookingInfoSection from '../../../components/bookings/BookingInfoSection';
 import FilesCard from '../../../components/FilesCard';
-import currency from 'currency.js';
 import PreviousBookingsCard from '../../../components/bookings/PreviousBookingsCard';
 import { BookingType } from '../../../models/enums/BookingType';
 import CalendarWorkersCard from '../../../components/bookings/CalendarWorkersCard';

--- a/src/pages/equipment/[id]/index.tsx
+++ b/src/pages/equipment/[id]/index.tsx
@@ -18,6 +18,7 @@ import EquipmentCalendar from '../../../components/equipment/EquipmentCalendar';
 import EquipmentBookings from '../../../components/equipment/EquipmentBookings';
 import EquipmentTagDisplay from '../../../components/utils/EquipmentTagDisplay';
 import EquipmentChangelogCard from '../../../components/EquipmentChangelogCard';
+import FilesCard from '../../../components/FilesCard';
 import MarkdownCard from '../../../components/MarkdownCard';
 import { KeyValue } from '../../../models/interfaces/KeyValue';
 import { getPricePlanName, getResponseContentOrError } from '../../../lib/utils';
@@ -182,6 +183,14 @@ const UserPage: React.FC<Props> = ({ user: currentUser, globalSettings }: Props)
                         </ListGroup>
                     </Card>
 
+                    <FilesCard
+                        driveFolderId={equipment.driveFolderId}
+                        defaultFolderName={equipment.name}
+                        driveType="equipment"
+                        onSubmit={(driveFolderId) => handleSubmit({ name: equipment.name, driveFolderId })}
+                        readonly={currentUser.role === Role.READONLY}
+                    />
+                    
                     <EquipmentChangelogCard changelog={equipment.changelog ?? []} />
                 </Col>
                 <Col xl={8}>


### PR DESCRIPTION
Add a drive integration for equipment, similar to boknings. For each equipment the user may create a drive folder and the files in the folder are shown in Backstage2. This can be used for manuals, spec sheets, backups of configurations, photos, etc. Most of this PR is just generalizing and reusing components/APIs from the booking integration.

Note: The env variable `DRIVE_ROOT_FOLDER_ID` has been renamed to `DRIVE_BOOKING_ROOT_FOLDER_ID` to align with the new `DRIVE_EQUIPMENT_ROOT_FOLDER_ID` variable.

<img width="1264" height="1171" alt="image" src="https://github.com/user-attachments/assets/eae505b5-6e8c-499c-ac7a-0c4fb241784a" />
<img width="631" height="363" alt="image" src="https://github.com/user-attachments/assets/dcfcbf56-d07c-4678-aa49-9387e575bd84" />
