### PR TITLE
Feature: Include price in changelog

### DIFF
--- a/knex/migrations/20260402000000_booking_changelog_prices.js
+++ b/knex/migrations/20260402000000_booking_changelog_prices.js
@@ -1,0 +1,17 @@
+exports.up = function (knex) {
+    return knex.schema.alterTable('BookingChangelogEntry', function (table) {
+        table.decimal('equipmentPrice', 10, 2).nullable();
+        table.decimal('timeEstimatePrice', 10, 2).nullable();
+        table.decimal('timeReportsPrice', 10, 2).nullable();
+        table.decimal('fixedPrice', 10, 2).nullable();
+    });
+};
+
+exports.down = function (knex) {
+    return knex.schema.alterTable('BookingChangelogEntry', function (table) {
+        table.dropColumn('equipmentPrice');
+        table.dropColumn('timeEstimatePrice');
+        table.dropColumn('timeReportsPrice');
+        table.dropColumn('fixedPrice');
+    });
+};

--- a/knex/migrations/20260402000000_booking_changelog_prices.js
+++ b/knex/migrations/20260402000000_booking_changelog_prices.js
@@ -1,4 +1,4 @@
-exports.up = function (knex) {
+export function up (knex) {
     return knex.schema.alterTable('BookingChangelogEntry', function (table) {
         table.decimal('equipmentPrice', 10, 2).nullable();
         table.decimal('timeEstimatePrice', 10, 2).nullable();
@@ -7,7 +7,7 @@ exports.up = function (knex) {
     });
 };
 
-exports.down = function (knex) {
+export function down (knex) {
     return knex.schema.alterTable('BookingChangelogEntry', function (table) {
         table.dropColumn('equipmentPrice');
         table.dropColumn('timeEstimatePrice');

--- a/src/components/EquipmentChangelogCard.tsx
+++ b/src/components/EquipmentChangelogCard.tsx
@@ -1,0 +1,54 @@
+import React, { useState } from 'react';
+import { Card, ListGroup, Modal } from 'react-bootstrap';
+import { formatDatetimeWithYear } from '../lib/datetimeUtils';
+import { EquipmentChangelogEntry } from '../models/interfaces/ChangeLogEntry';
+
+type Props = {
+    changelog: EquipmentChangelogEntry[];
+};
+
+const defaultListLength = 3;
+
+const EquipmentChangelogCard: React.FC<Props> = ({ changelog }: Props) => {
+    const [showAllModal, setShowAllModal] = useState(false);
+
+    return (
+        <>
+            <Card className="mb-3">
+                <Card.Header className="d-flex">
+                    <span className="flex-grow-1">Senaste ändringar</span>
+                    <a href="#" onClick={() => setShowAllModal(true)}>
+                        Visa alla ({changelog.length})
+                    </a>
+                </Card.Header>
+                <ListGroup variant="flush">
+                    {changelog.slice(0, defaultListLength).map((changelogEntry) => (
+                        <ListGroup.Item key={changelogEntry.id}>
+                            <div className="mb-1">{changelogEntry.name}</div>
+                            <div className="text-muted">
+                                {changelogEntry.updated ? formatDatetimeWithYear(changelogEntry.updated) : 'N/A'}
+                            </div>
+                        </ListGroup.Item>
+                    ))}
+                </ListGroup>
+            </Card>
+            <Modal show={showAllModal} onHide={() => setShowAllModal(false)} size="lg" backdrop="static">
+                <Modal.Header closeButton>
+                    <Modal.Title>Ändringshistorik</Modal.Title>
+                </Modal.Header>
+                <ListGroup variant="flush">
+                    {changelog.map((changelogEntry) => (
+                        <ListGroup.Item key={changelogEntry.id}>
+                            <div className="mb-1">{changelogEntry.name}</div>
+                            <div className="text-muted">
+                                {changelogEntry.updated ? formatDatetimeWithYear(changelogEntry.updated) : 'N/A'}
+                            </div>
+                        </ListGroup.Item>
+                    ))}
+                </ListGroup>
+            </Modal>
+        </>
+    );
+};
+
+export default EquipmentChangelogCard;

--- a/src/components/bookings/BookingChangelogCard.tsx
+++ b/src/components/bookings/BookingChangelogCard.tsx
@@ -35,7 +35,7 @@ const ChangelogEntryContent: React.FC<{ entry: BookingChangelogEntry; onClick?: 
 
     return (
         <ListGroup.Item key={entry.id}>
-            <div style={{ cursor: 'pointer' }} onClick={onClick}>
+            <div style={onClick ? { cursor: 'pointer' } : {}} onClick={onClick}>
                 {entry.name}
             </div>
             {displayPrice !== null ? <div className="text-muted">{formatCurrency(displayPrice)}</div> : null}

--- a/src/components/bookings/BookingChangelogCard.tsx
+++ b/src/components/bookings/BookingChangelogCard.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { Card, ListGroup, Modal } from 'react-bootstrap';
 import { formatDatetimeWithYear } from '../../lib/datetimeUtils';
-import { addVAT, formatCurrency, getCorrectPriceBasedOnBookingState } from '../../lib/pricingUtils';
+import { addVAT, formatCurrency, getCorrectPriceBasedOnBookingState, getPriceCalculationType, PriceCalculationType } from '../../lib/pricingUtils';
 import { BookingChangelogEntry } from '../../models/interfaces/ChangeLogEntry';
 import BookingPriceSummaryDisplay from './BookingPriceSummary';
 import currency from 'currency.js';
@@ -12,16 +12,27 @@ type Props = {
 
 const defaultListLength = 3;
 
+const getPriceSummaryFromEntry = (entry: BookingChangelogEntry) => ({
+    equipmentPrice: entry.equipmentPrice ?? currency(0),
+    timeEstimatePrice: entry.timeEstimatePrice ?? currency(0),
+    timeReportsPrice: entry.timeReportsPrice ?? null,
+    fixedPrice: entry.fixedPrice ?? null,
+});
+
+const priceCalculationTypeLabels: Record<PriceCalculationType, string> = {
+    fixedPrice: 'Fast pris',
+    timeReports: 'Faktisk personalkostnad',
+    timeEstimates: 'Estimerad personalkostnad',
+};
+
 const getDisplayPrice = (entry: BookingChangelogEntry): currency | null => {
     if (!hasPriceInformation(entry)) return null;
-    return addVAT(
-        getCorrectPriceBasedOnBookingState({
-            equipmentPrice: entry.equipmentPrice ?? currency(0),
-            timeEstimatePrice: entry.timeEstimatePrice ?? currency(0),
-            timeReportsPrice: entry.timeReportsPrice ?? null,
-            fixedPrice: entry.fixedPrice ?? null,
-        }),
-    );
+    return addVAT(getCorrectPriceBasedOnBookingState(getPriceSummaryFromEntry(entry)));
+};
+
+const getPriceTypeLabel = (entry: BookingChangelogEntry): string | null => {
+    if (!hasPriceInformation(entry)) return null;
+    return priceCalculationTypeLabels[getPriceCalculationType(getPriceSummaryFromEntry(entry))];
 };
 
 const hasPriceInformation = (entry: BookingChangelogEntry): boolean =>
@@ -32,13 +43,19 @@ const ChangelogEntryContent: React.FC<{ entry: BookingChangelogEntry; onClick?: 
     onClick,
 }) => {
     const displayPrice = getDisplayPrice(entry);
+    const priceTypeLabel = getPriceTypeLabel(entry);
 
     return (
         <ListGroup.Item key={entry.id}>
             <div style={onClick ? { cursor: 'pointer' } : {}} onClick={onClick}>
                 {entry.name}
             </div>
-            {displayPrice !== null ? <div className="text-muted">{formatCurrency(displayPrice)}</div> : null}
+            {displayPrice !== null ? (
+                <div className="text-muted">
+                    {formatCurrency(displayPrice)}{' '}
+                    {priceTypeLabel !== null ? <span className="ms-1">({priceTypeLabel})</span> : null}
+                </div>
+            ) : null}
             <div className="text-muted">{entry.updated ? formatDatetimeWithYear(entry.updated) : 'N/A'}</div>
         </ListGroup.Item>
     );

--- a/src/components/bookings/BookingChangelogCard.tsx
+++ b/src/components/bookings/BookingChangelogCard.tsx
@@ -1,0 +1,130 @@
+import React, { useState } from 'react';
+import { Card, ListGroup, Modal } from 'react-bootstrap';
+import { formatDatetimeWithYear } from '../../lib/datetimeUtils';
+import { addVAT, formatCurrency, getCorrectPriceBasedOnBookingState } from '../../lib/pricingUtils';
+import { BookingChangelogEntry } from '../../models/interfaces/ChangeLogEntry';
+import BookingPriceSummaryDisplay from './BookingPriceSummary';
+import currency from 'currency.js';
+
+type Props = {
+    changelog: BookingChangelogEntry[];
+};
+
+const defaultListLength = 3;
+
+const getDisplayPrice = (entry: BookingChangelogEntry): currency | null => {
+    if (!hasPriceInformation(entry)) return null;
+    return addVAT(
+        getCorrectPriceBasedOnBookingState({
+            equipmentPrice: entry.equipmentPrice ?? currency(0),
+            timeEstimatePrice: entry.timeEstimatePrice ?? currency(0),
+            timeReportsPrice: entry.timeReportsPrice ?? null,
+            fixedPrice: entry.fixedPrice ?? null,
+        }),
+    );
+};
+
+const hasPriceInformation = (entry: BookingChangelogEntry): boolean =>
+    entry.equipmentPrice !== null && entry.equipmentPrice !== undefined;
+
+const ChangelogEntryContent: React.FC<{ entry: BookingChangelogEntry; onClick?: () => void }> = ({
+    entry,
+    onClick,
+}) => {
+    const displayPrice = getDisplayPrice(entry);
+
+    return (
+        <ListGroup.Item key={entry.id}>
+            <div style={{ cursor: 'pointer' }} onClick={onClick}>
+                {entry.name}
+            </div>
+            {displayPrice !== null ? <div className="text-muted">{formatCurrency(displayPrice)}</div> : null}
+            <div className="text-muted">{entry.updated ? formatDatetimeWithYear(entry.updated) : 'N/A'}</div>
+        </ListGroup.Item>
+    );
+};
+
+const BookingChangelogCard: React.FC<Props> = ({ changelog }: Props) => {
+    const [showAllModal, setShowAllModal] = useState(false);
+    const [selectedEntry, setSelectedEntry] = useState<BookingChangelogEntry | null>(null);
+
+    const handleEntryClick = (entry: BookingChangelogEntry) => {
+        if (hasPriceInformation(entry)) {
+            setSelectedEntry(entry);
+        }
+    };
+
+    return (
+        <>
+            <Card className="mb-3">
+                <Card.Header className="d-flex">
+                    <span className="flex-grow-1">Senaste ändringar</span>
+                    <a href="#" onClick={() => setShowAllModal(true)}>
+                        Visa alla ({changelog.length})
+                    </a>
+                </Card.Header>
+                <ListGroup variant="flush">
+                    {changelog.slice(0, defaultListLength).map((entry) => (
+                        <ChangelogEntryContent
+                            key={entry.id}
+                            entry={entry}
+                            onClick={hasPriceInformation(entry) ? () => handleEntryClick(entry) : undefined}
+                        />
+                    ))}
+                </ListGroup>
+            </Card>
+
+            <Modal show={showAllModal} onHide={() => setShowAllModal(false)} size="lg" backdrop="static">
+                <Modal.Header closeButton>
+                    <Modal.Title>Ändringshistorik</Modal.Title>
+                </Modal.Header>
+                <ListGroup variant="flush">
+                    {changelog.map((entry) => (
+                        <ChangelogEntryContent
+                            key={entry.id}
+                            entry={entry}
+                            onClick={
+                                hasPriceInformation(entry)
+                                    ? () => {
+                                          setShowAllModal(false);
+                                          setSelectedEntry(entry);
+                                      }
+                                    : undefined
+                            }
+                        />
+                    ))}
+                </ListGroup>
+            </Modal>
+
+            <Modal show={selectedEntry !== null} onHide={() => setSelectedEntry(null)} size="lg">
+                {selectedEntry !== null && hasPriceInformation(selectedEntry) ? (
+                    <>
+                        <Modal.Header closeButton>
+                            <Modal.Title>{selectedEntry.updated ? formatDatetimeWithYear(selectedEntry.updated) : 'N/A'} - {selectedEntry?.name}</Modal.Title>
+                        </Modal.Header>
+
+                        <Modal.Body className="p-0">
+                            <Card className="mt-3">
+                                <Card.Header>
+                                    Prisinformation (inkl. moms)
+                                </Card.Header>
+                                <Card.Body>
+                                    <BookingPriceSummaryDisplay
+                                        bookingPriceSummary={{
+                                            equipmentPrice: selectedEntry.equipmentPrice ?? currency(0),
+                                            timeEstimatePrice: selectedEntry.timeEstimatePrice ?? currency(0),
+                                            timeReportsPrice: selectedEntry.timeReportsPrice ?? null,
+                                            fixedPrice: selectedEntry.fixedPrice ?? null,
+                                        }}
+                                    />
+                                </Card.Body>
+                            </Card>
+                        </Modal.Body>
+                    </>
+                ) : null}
+            </Modal>
+        </>
+    );
+};
+
+export default BookingChangelogCard;

--- a/src/components/bookings/BookingChangelogCard.tsx
+++ b/src/components/bookings/BookingChangelogCard.tsx
@@ -21,8 +21,8 @@ const getPriceSummaryFromEntry = (entry: BookingChangelogEntry) => ({
 
 const priceCalculationTypeLabels: Record<PriceCalculationType, string> = {
     fixedPrice: 'Fast pris',
-    timeReports: 'Faktisk personalkostnad',
-    timeEstimates: 'Estimerad personalkostnad',
+    timeReports: 'Pris med faktisk personalkostnad',
+    timeEstimates: 'Pris med estimerad personalkostnad',
 };
 
 const getDisplayPrice = (entry: BookingChangelogEntry): currency | null => {

--- a/src/components/bookings/BookingPriceSummary.tsx
+++ b/src/components/bookings/BookingPriceSummary.tsx
@@ -1,0 +1,99 @@
+import React from 'react';
+import { ListGroup } from 'react-bootstrap';
+import { addVAT, BookingPriceSummary, formatCurrency, getVAT } from '../../lib/pricingUtils';
+import currency from 'currency.js';
+
+type EquipmentListDetail = {
+    id: number | string;
+    name: string;
+    price: currency;
+};
+
+type Props = {
+    bookingPriceSummary: BookingPriceSummary;
+    equipmentListDetails?: EquipmentListDetail[];
+};
+
+const BookingPriceSummaryDisplay: React.FC<Props> = ({
+    bookingPriceSummary: snapshot,
+    equipmentListDetails,
+}: Props) => {
+    const { equipmentPrice, timeEstimatePrice, timeReportsPrice, fixedPrice } = snapshot;
+
+    const priceWithEstimate = equipmentPrice.add(timeEstimatePrice);
+    const priceWithReports = timeReportsPrice !== null ? equipmentPrice.add(timeReportsPrice) : null;
+
+    const equipmentListRows = equipmentListDetails ?? [
+        { name: 'Utrustningslistor totalt', price: equipmentPrice } as EquipmentListDetail,
+    ];
+
+    return (
+        <ListGroup variant="flush">
+            {equipmentListRows.map((list) => (
+                <ListGroup.Item className="d-flex" key={list.id}>
+                    <span className="flex-grow-1">{list.name}</span>
+                    <span>{formatCurrency(addVAT(list.price))}</span>
+                </ListGroup.Item>
+            ))}
+            <ListGroup.Item className="d-flex">
+                <span className="flex-grow-1">Estimerad personalkostnad</span>
+                <span>{formatCurrency(addVAT(timeEstimatePrice))}</span>
+            </ListGroup.Item>
+            <ListGroup.Item className="d-flex">
+                <strong className="flex-grow-1">Pris med estimerad personalkostnad</strong>
+                <strong>{formatCurrency(addVAT(priceWithEstimate))}</strong>
+            </ListGroup.Item>
+            <ListGroup.Item className="d-flex">
+                <em className="flex-grow-1 pl-4">varav moms (25%)</em>
+                <em>{formatCurrency(getVAT(priceWithEstimate))}</em>
+            </ListGroup.Item>
+
+            {timeReportsPrice !== null && priceWithReports !== null ? (
+                <>
+                    <ListGroup.Item className="d-flex">
+                        <span className="flex-grow-1">Faktisk personalkostnad</span>
+                        <span>{formatCurrency(addVAT(timeReportsPrice))}</span>
+                    </ListGroup.Item>
+                    <ListGroup.Item className="d-flex">
+                        <strong className="flex-grow-1">Pris med faktisk personalkostnad</strong>
+                        <strong>{formatCurrency(addVAT(priceWithReports))}</strong>
+                    </ListGroup.Item>
+                    <ListGroup.Item className="d-flex">
+                        <em className="flex-grow-1 pl-4">varav moms (25%)</em>
+                        <em>{formatCurrency(getVAT(priceWithReports))}</em>
+                    </ListGroup.Item>
+                    <ListGroup.Item className="d-flex">
+                        <span className="flex-grow-1">Skillnad mot estimerad personalkostnad</span>
+                        <span>{formatCurrency(addVAT(priceWithReports.subtract(priceWithEstimate)), true)}</span>
+                    </ListGroup.Item>
+                </>
+            ) : null}
+
+            {fixedPrice !== null ? (
+                <>
+                    <ListGroup.Item className="d-flex">
+                        <strong className="flex-grow-1">Fast pris</strong>
+                        <strong>{formatCurrency(addVAT(fixedPrice))}</strong>
+                    </ListGroup.Item>
+                    <ListGroup.Item className="d-flex">
+                        <em className="flex-grow-1 pl-4">varav moms (25%)</em>
+                        <em>{formatCurrency(getVAT(fixedPrice))}</em>
+                    </ListGroup.Item>
+                    {priceWithReports !== null ? (
+                        <ListGroup.Item className="d-flex">
+                            <span className="flex-grow-1">Skillnad mot pris med faktisk personalkostnad</span>
+                            <span>{formatCurrency(addVAT(fixedPrice.subtract(priceWithReports)), true)}</span>
+                        </ListGroup.Item>
+                    ) : (
+                        <ListGroup.Item className="d-flex">
+                            <span className="flex-grow-1">Skillnad mot pris med estimerad personalkostnad</span>
+                            <span>{formatCurrency(addVAT(fixedPrice.subtract(priceWithEstimate)), true)}</span>
+                        </ListGroup.Item>
+                    )}
+                </>
+            ) : null}
+        </ListGroup>
+    );
+};
+
+export default BookingPriceSummaryDisplay;

--- a/src/lib/changelogUtils.ts
+++ b/src/lib/changelogUtils.ts
@@ -3,6 +3,7 @@ import { RentalStatus } from '../models/enums/RentalStatus';
 import { SalaryStatus } from '../models/enums/SalaryStatus';
 import { Status } from '../models/enums/Status';
 import { HasId } from '../models/interfaces/BaseEntity';
+import { BookingPriceSummary } from './pricingUtils';
 import { CurrentUserInfo } from '../models/misc/CurrentUserInfo';
 import { EquipmentChangelogEntryObjectionModel } from '../models/objection-models';
 import { BookingChangelogEntryObjectionModel } from '../models/objection-models/BookingObjectionModel';
@@ -101,18 +102,34 @@ const getPaymentStatusActionString = (type: PaymentStatus | null) => {
 };
 
 // The deDuplicateTimeout is how far back (in seconds) we should look for a log entry to update instead of creating a new (duplicate one). Default is fifteen minutes (900 seconds).
-const addChangelogToBooking = async (message: string, bookingId: number, deDuplicateTimeout = 900) => {
+const addChangelogToBooking = async (
+    message: string,
+    bookingId: number,
+    deDuplicateTimeout = 900,
+    priceSummary: BookingPriceSummary,
+) => {
+    const priceInformation = {
+        equipmentPrice: priceSummary.equipmentPrice.value,
+        timeEstimatePrice: priceSummary.timeEstimatePrice.value,
+        timeReportsPrice: priceSummary.timeReportsPrice?.value ?? null,
+        fixedPrice: priceSummary.fixedPrice?.value ?? null,
+    };
+
     const logEntries = await fetchBookingChangelogEntrysByBookingId(bookingId);
     const existingLogEntryToUpdate = getExistingLogEntryToUpdate(logEntries, message, deDuplicateTimeout);
 
     if (existingLogEntryToUpdate) {
-        updateBookingChangelogEntry(existingLogEntryToUpdate.id, existingLogEntryToUpdate);
+        updateBookingChangelogEntry(existingLogEntryToUpdate.id, {
+            ...existingLogEntryToUpdate,
+            ...priceInformation,
+        } as BookingChangelogEntryObjectionModel);
         return message;
     }
 
     insertBookingChangelogEntry({
         name: message,
         bookingId: bookingId,
+        ...priceInformation,
     });
 
     return message;
@@ -123,6 +140,7 @@ export const logChangeToBooking = (
     bookingId: number,
     bookingName: string,
     type = BookingChangelogEntryType.BOOKING,
+    priceSummary: BookingPriceSummary,
 ) => {
     const message = `${user.name} ${getBookingEditActionString(type)}.`;
 
@@ -130,7 +148,7 @@ export const logChangeToBooking = (
         sendSlackMessageForBooking(message, bookingId, bookingName);
     }
 
-    return addChangelogToBooking(message, bookingId);
+    return addChangelogToBooking(message, bookingId, 900, priceSummary);
 };
 
 export const logStatusChangeToBooking = (
@@ -138,13 +156,14 @@ export const logStatusChangeToBooking = (
     bookingId: number,
     bookingName: string,
     newStatus: Status,
+    priceSummary: BookingPriceSummary,
 ) => {
     const message = `${user.name} ${getStatusActionString(newStatus)}.`;
 
     sendSlackMessageForBooking(message, bookingId, bookingName);
     sendSlackDMForBooking(message, bookingId, bookingName, user);
 
-    return addChangelogToBooking(message, bookingId, 0);
+    return addChangelogToBooking(message, bookingId, 0, priceSummary);
 };
 
 export const logSalaryStatusChangeToBooking = (
@@ -152,11 +171,12 @@ export const logSalaryStatusChangeToBooking = (
     bookingId: number,
     bookingName: string,
     newStatus: SalaryStatus,
+    priceSummary: BookingPriceSummary,
 ) => {
     const message = `${user.name} ${getSalaryStatusActionString(newStatus)}.`;
 
     sendSlackMessageForBooking(message, bookingId, bookingName);
-    return addChangelogToBooking(message, bookingId, 0);
+    return addChangelogToBooking(message, bookingId, 0, priceSummary);
 };
 
 export const logOwnerUserChangeToBooking = (
@@ -165,11 +185,12 @@ export const logOwnerUserChangeToBooking = (
     bookingName: string,
     oldOwnerUserName: string | null,
     newOwnerUserName: string | null,
+    priceSummary: BookingPriceSummary,
 ) => {
     const message = `${user.name} ändrade ansvarig från ${oldOwnerUserName} till ${newOwnerUserName}.`;
 
     sendSlackMessageForBooking(message, bookingId, bookingName);
-    return addChangelogToBooking(message, bookingId, 0);
+    return addChangelogToBooking(message, bookingId, 0, priceSummary);
 };
 
 export const logRentalStatusChangeToBooking = (
@@ -178,13 +199,14 @@ export const logRentalStatusChangeToBooking = (
     bookingName: string,
     equipmentListName: string,
     newStatus: RentalStatus | null,
+    priceSummary: BookingPriceSummary,
 ) => {
     const message = `${user.name} ${getRentalStatusActionString(newStatus)} ${equipmentListName}.`;
 
     sendSlackMessageForBooking(message, bookingId, bookingName);
     sendSlackDMForBooking(message, bookingId, bookingName, user);
 
-    return addChangelogToBooking(message, bookingId, 0);
+    return addChangelogToBooking(message, bookingId, 0, priceSummary);
 };
 
 export const logBookingDeletion = (user: CurrentUserInfo, bookingId: number, bookingName: string, reason: string) => {
@@ -198,17 +220,23 @@ export const logPaymentStatusChangeToBooking = (
     bookingId: number,
     bookingName: string,
     newStatus: PaymentStatus | null,
+    priceSummary: BookingPriceSummary,
 ) => {
     const message = `${user.name} ${getPaymentStatusActionString(newStatus)}.`;
 
     sendSlackMessageForBooking(message, bookingId, bookingName);
-    return addChangelogToBooking(message, bookingId, 0);
+    return addChangelogToBooking(message, bookingId, 0, priceSummary);
 };
 
-export const logMessageSentToBookingOwner = (user: CurrentUserInfo, bookingId: number, bookingOwner: string) => {
+export const logMessageSentToBookingOwner = (
+    user: CurrentUserInfo,
+    bookingId: number,
+    bookingOwner: string,
+    priceSummary: BookingPriceSummary,
+) => {
     const message = `${user.name} skickade ett meddelande till ansvarig ${bookingOwner}.`;
 
-    return addChangelogToBooking(message, bookingId);
+    return addChangelogToBooking(message, bookingId, 900, priceSummary);
 };
 
 // Equipment

--- a/src/lib/db-access/booking.ts
+++ b/src/lib/db-access/booking.ts
@@ -215,6 +215,7 @@ export const fetchBookingWithEquipmentLists = async (id: number): Promise<Bookin
         .withGraphFetched('equipmentLists.listEntries.equipment.equipmentLocation')
         .withGraphFetched('equipmentLists.listHeadings.listEntries.equipment.equipmentLocation')
         .withGraphFetched('timeEstimates')
+        .withGraphFetched('timeReports')
         .withGraphFetched('changelog(changelogInfo)')
         .modifiers({
             changelogInfo: (builder) => {

--- a/src/lib/mappers/booking.ts
+++ b/src/lib/mappers/booking.ts
@@ -106,6 +106,14 @@ export const toBookingChangelogEntry = (
         id: objectionModel.id,
         updated: toDatetimeOrUndefined(objectionModel.updated),
         created: toDatetimeOrUndefined(objectionModel.created),
+        equipmentPrice: objectionModel.equipmentPrice != null ? currency(objectionModel.equipmentPrice) : undefined,
+        timeEstimatePrice:
+            objectionModel.timeEstimatePrice != null ? currency(objectionModel.timeEstimatePrice) : undefined,
+        timeReportsPrice:
+            objectionModel.timeReportsPrice != null
+                ? currency(objectionModel.timeReportsPrice)
+                : objectionModel.timeReportsPrice,
+        fixedPrice: objectionModel.fixedPrice != null ? currency(objectionModel.fixedPrice) : objectionModel.fixedPrice,
     };
 };
 

--- a/src/lib/pricingUtils.ts
+++ b/src/lib/pricingUtils.ts
@@ -140,6 +140,22 @@ export const computePriceSummary = (booking: Booking): BookingPriceSummary => {
     };
 };
 
+export type PriceCalculationType = 'fixedPrice' | 'timeReports' | 'timeEstimates';
+
+export const getPriceCalculationType = (
+    summary: BookingPriceSummary,
+    forceEstimatedTime = false,
+    forceNoFixedPrice = false,
+): PriceCalculationType => {
+    if (!forceNoFixedPrice && summary.fixedPrice !== null) {
+        return 'fixedPrice';
+    }
+    if (!forceEstimatedTime && summary.timeReportsPrice !== null) {
+        return 'timeReports';
+    }
+    return 'timeEstimates';
+};
+
 export const getCorrectPriceBasedOnBookingState = (
     summary: BookingPriceSummary,
     forceEstimatedTime = false,
@@ -147,13 +163,14 @@ export const getCorrectPriceBasedOnBookingState = (
 ): currency => {
     const { fixedPrice, timeReportsPrice, equipmentPrice, timeEstimatePrice } = summary;
 
-    if (!forceNoFixedPrice && fixedPrice !== null) {
-        return fixedPrice;
+    switch (getPriceCalculationType(summary, forceEstimatedTime, forceNoFixedPrice)) {
+        case 'fixedPrice':
+            return fixedPrice!;
+        case 'timeReports':
+            return equipmentPrice.add(timeReportsPrice!);
+        case 'timeEstimates':
+            return equipmentPrice.add(timeEstimatePrice);
     }
-    if (!forceEstimatedTime && timeReportsPrice !== null) {
-        return equipmentPrice.add(timeReportsPrice);
-    }
-    return equipmentPrice.add(timeEstimatePrice);
 };
 
 export const getBookingPrice = (booking: Booking, forceEstimatedTime = false, forceNoFixedPrice = false): currency =>

--- a/src/lib/pricingUtils.ts
+++ b/src/lib/pricingUtils.ts
@@ -116,25 +116,48 @@ export const getTotalTimeReportsPrice = (timeReports: TimeReport[] | undefined):
     return timeReports?.reduce((sum, l) => sum.add(getTimeReportPrice(l)), currency(0)) ?? currency(0);
 };
 
-export const getBookingPrice = (booking: Booking, forceEstimatedTime = false, forceNoFixedPrice = false): currency => {
-    if (!forceNoFixedPrice && booking.fixedPrice !== null && booking.fixedPrice !== undefined) {
-        return currency(booking.fixedPrice);
-    }
+export const addVAT = (price: currency | number): currency => currency(price).add(getVAT(price));
+export const getVAT = (price: currency | number): currency => currency(price).multiply(0.25);
 
+export type BookingPriceSummary = {
+    equipmentPrice: currency;
+    timeEstimatePrice: currency;
+    timeReportsPrice: currency | null;
+    fixedPrice: currency | null;
+};
+
+export const computePriceSummary = (booking: Booking): BookingPriceSummary => {
     const equipmentPrice =
         booking.equipmentLists?.reduce((sum, l) => sum.add(getEquipmentListPrice(l)), currency(0)) ?? currency(0);
     const timeEstimatePrice = getTotalTimeEstimatesPrice(booking.timeEstimates);
-    const timeReportsPrice = getTotalTimeReportsPrice(booking.timeReports);
+    const timeReportsPrice =
+        booking.timeReports && booking.timeReports.length > 0 ? getTotalTimeReportsPrice(booking.timeReports) : null;
+    return {
+        equipmentPrice,
+        timeEstimatePrice,
+        timeReportsPrice,
+        fixedPrice: booking.fixedPrice != null ? currency(booking.fixedPrice) : null,
+    };
+};
 
-    if (!forceEstimatedTime && booking.timeReports && booking.timeReports.length > 0) {
+export const getCorrectPriceBasedOnBookingState = (
+    summary: BookingPriceSummary,
+    forceEstimatedTime = false,
+    forceNoFixedPrice = false,
+): currency => {
+    const { fixedPrice, timeReportsPrice, equipmentPrice, timeEstimatePrice } = summary;
+
+    if (!forceNoFixedPrice && fixedPrice !== null) {
+        return fixedPrice;
+    }
+    if (!forceEstimatedTime && timeReportsPrice !== null) {
         return equipmentPrice.add(timeReportsPrice);
     }
-
     return equipmentPrice.add(timeEstimatePrice);
 };
 
-export const addVAT = (price: currency | number): currency => currency(price).add(getVAT(price));
-export const getVAT = (price: currency | number): currency => currency(price).multiply(0.25);
+export const getBookingPrice = (booking: Booking, forceEstimatedTime = false, forceNoFixedPrice = false): currency =>
+    getCorrectPriceBasedOnBookingState(computePriceSummary(booking), forceEstimatedTime, forceNoFixedPrice);
 
 export const addVATToPrice = (price: PricedEntity): PricedEntity => ({
     pricePerHour: addVAT(price.pricePerHour),

--- a/src/models/interfaces/ChangeLogEntry.ts
+++ b/src/models/interfaces/ChangeLogEntry.ts
@@ -1,4 +1,10 @@
 import { BaseEntityWithName } from './BaseEntity';
+import currency from 'currency.js';
 
-export type BookingChangelogEntry = BaseEntityWithName;
+export interface BookingChangelogEntry extends BaseEntityWithName {
+    equipmentPrice?: currency;
+    timeEstimatePrice?: currency;
+    timeReportsPrice?: currency | null;
+    fixedPrice?: currency | null;
+}
 export type EquipmentChangelogEntry = BaseEntityWithName;

--- a/src/models/objection-models/BookingObjectionModel.ts
+++ b/src/models/objection-models/BookingObjectionModel.ts
@@ -358,6 +358,10 @@ export interface IBookingChangelogEntryObjectionModel extends BaseObjectionModel
     created: string;
     updated: string;
     bookingId: number;
+    equipmentPrice?: number | null;
+    timeEstimatePrice?: number | null;
+    timeReportsPrice?: number | null;
+    fixedPrice?: number | null;
 }
 
 export class BookingChangelogEntryObjectionModel extends Model {
@@ -368,4 +372,8 @@ export class BookingChangelogEntryObjectionModel extends Model {
     created!: string;
     updated!: string;
     bookingId!: number;
+    equipmentPrice?: number | null;
+    timeEstimatePrice?: number | null;
+    timeReportsPrice?: number | null;
+    fixedPrice?: number | null;
 }

--- a/src/pages/api/bookings/[bookingId]/equipmentListEntry/[equipmentListEntryId].ts
+++ b/src/pages/api/bookings/[bookingId]/equipmentListEntry/[equipmentListEntryId].ts
@@ -9,6 +9,8 @@ import { SessionContext, withSessionContext } from '../../../../../lib/sessionCo
 import { Status } from '../../../../../models/enums/Status';
 import { BookingChangelogEntryType, hasChanges, logChangeToBooking } from '../../../../../lib/changelogUtils';
 import { fetchBookingWithEquipmentLists } from '../../../../../lib/db-access/booking';
+import { toBooking } from '../../../../../lib/mappers/booking';
+import { computePriceSummary } from '../../../../../lib/pricingUtils';
 import {
     deleteEquipmentListEntry,
     fetchEquipmentListEntry,
@@ -53,11 +55,13 @@ const handler = withSessionContext(
                     return;
                 }
 
+                const priceSnapshotForDelete = computePriceSummary(toBooking(booking));
                 await logChangeToBooking(
                     context.currentUser,
                     bookingId,
                     booking.name,
                     BookingChangelogEntryType.EQUIPMENTLIST,
+                    priceSnapshotForDelete,
                 );
 
                 await deleteEquipmentListEntry(equipmentListEntryId)
@@ -83,11 +87,14 @@ const handler = withSessionContext(
                 await updateEquipmentListEntry(equipmentListEntryId, req.body.equipmentListEntry)
                     .then(async (result) => {
                         if (hasChanges(oldEquipmentListEntry, req.body.equipmentListEntry, ['isPacked'])) {
+                            const fullBooking = await fetchBookingWithEquipmentLists(bookingId).then(toBooking);
+                            const priceSnapshot = computePriceSummary(fullBooking);
                             await logChangeToBooking(
                                 context.currentUser,
                                 bookingId,
                                 booking.name,
                                 BookingChangelogEntryType.EQUIPMENTLIST,
+                                priceSnapshot,
                             );
                         }
 

--- a/src/pages/api/bookings/[bookingId]/equipmentListEntry/index.ts
+++ b/src/pages/api/bookings/[bookingId]/equipmentListEntry/index.ts
@@ -8,9 +8,11 @@ import {
 } from '../../../../../lib/apiResponses';
 import { SessionContext, withSessionContext } from '../../../../../lib/sessionContext';
 import { fetchBooking } from '../../../../../lib/db-access';
+import { fetchBookingWithEquipmentLists } from '../../../../../lib/db-access/booking';
 import { toBooking } from '../../../../../lib/mappers/booking';
 import { Status } from '../../../../../models/enums/Status';
 import { logChangeToBooking, BookingChangelogEntryType } from '../../../../../lib/changelogUtils';
+import { computePriceSummary } from '../../../../../lib/pricingUtils';
 import {
     insertEquipmentListEntry,
     validateEquipmentListEntryObjectionModel,
@@ -53,12 +55,15 @@ const handler = withSessionContext(
                     isNaN(equipmentListId) ? undefined : equipmentListId,
                     isNaN(equipmentListHeadingId) ? undefined : equipmentListHeadingId,
                 )
-                    .then((result) => {
+                    .then(async (result) => {
+                        const fullBooking = await fetchBookingWithEquipmentLists(bookingId).then(toBooking);
+                        const priceSnapshot = computePriceSummary(fullBooking);
                         logChangeToBooking(
                             context.currentUser,
                             bookingId,
                             booking.name,
                             BookingChangelogEntryType.EQUIPMENTLIST,
+                            priceSnapshot,
                         ).then(() => res.status(200).json(result));
                     })
                     .catch((err) => res.status(500).json({ statusCode: 500, message: err.message }));

--- a/src/pages/api/bookings/[bookingId]/equipmentListHeading/[equipmentListHeadingId].ts
+++ b/src/pages/api/bookings/[bookingId]/equipmentListHeading/[equipmentListHeadingId].ts
@@ -9,6 +9,8 @@ import { SessionContext, withSessionContext } from '../../../../../lib/sessionCo
 import { Status } from '../../../../../models/enums/Status';
 import { BookingChangelogEntryType, logChangeToBooking } from '../../../../../lib/changelogUtils';
 import { fetchBookingWithEquipmentLists } from '../../../../../lib/db-access/booking';
+import { toBooking } from '../../../../../lib/mappers/booking';
+import { computePriceSummary } from '../../../../../lib/pricingUtils';
 import {
     deleteEquipmentListHeading,
     fetchEquipmentListHeading,
@@ -54,11 +56,13 @@ const handler = withSessionContext(
                     return;
                 }
 
+                const priceSnapshotForDelete = computePriceSummary(toBooking(booking));
                 await logChangeToBooking(
                     context.currentUser,
                     bookingId,
                     booking.name,
                     BookingChangelogEntryType.EQUIPMENTLIST,
+                    priceSnapshotForDelete,
                 );
 
                 await deleteEquipmentListHeading(equipmentListHeadingId)
@@ -83,11 +87,14 @@ const handler = withSessionContext(
 
                 await updateEquipmentListHeading(equipmentListHeadingId, req.body.equipmentListHeading)
                     .then(async (result) => {
+                        const fullBooking = await fetchBookingWithEquipmentLists(bookingId).then(toBooking);
+                        const priceSnapshot = computePriceSummary(fullBooking);
                         await logChangeToBooking(
                             context.currentUser,
                             bookingId,
                             booking.name,
                             BookingChangelogEntryType.EQUIPMENTLIST,
+                            priceSnapshot,
                         );
 
                         res.status(200).json(result);

--- a/src/pages/api/bookings/[bookingId]/equipmentListHeading/index.ts
+++ b/src/pages/api/bookings/[bookingId]/equipmentListHeading/index.ts
@@ -8,9 +8,11 @@ import {
 } from '../../../../../lib/apiResponses';
 import { SessionContext, withSessionContext } from '../../../../../lib/sessionContext';
 import { fetchBooking } from '../../../../../lib/db-access';
+import { fetchBookingWithEquipmentLists } from '../../../../../lib/db-access/booking';
 import { toBooking } from '../../../../../lib/mappers/booking';
 import { Status } from '../../../../../models/enums/Status';
 import { logChangeToBooking, BookingChangelogEntryType } from '../../../../../lib/changelogUtils';
+import { computePriceSummary } from '../../../../../lib/pricingUtils';
 import {
     insertEquipmentListHeading,
     validateEquipmentListHeadingObjectionModel,
@@ -49,11 +51,14 @@ const handler = withSessionContext(
 
                 await insertEquipmentListHeading(req.body.equipmentListHeading, equipmentListId)
                     .then(async (result) => {
+                        const fullBooking = await fetchBookingWithEquipmentLists(bookingId).then(toBooking);
+                        const priceSnapshot = computePriceSummary(fullBooking);
                         await logChangeToBooking(
                             context.currentUser,
                             bookingId,
                             booking.name,
                             BookingChangelogEntryType.EQUIPMENTLIST,
+                            priceSnapshot,
                         ).then(() => res.status(200).json(result));
                     })
                     .catch((err) => res.status(500).json({ statusCode: 500, message: err.message }));

--- a/src/pages/api/bookings/[bookingId]/equipmentLists/[equipmentListId].ts
+++ b/src/pages/api/bookings/[bookingId]/equipmentLists/[equipmentListId].ts
@@ -23,6 +23,8 @@ import {
 } from '../../../../../lib/changelogUtils';
 import { EquipmentListObjectionModel } from '../../../../../models/objection-models/BookingObjectionModel';
 import { fetchBookingWithEquipmentLists } from '../../../../../lib/db-access/booking';
+import { toBooking } from '../../../../../lib/mappers/booking';
+import { computePriceSummary } from '../../../../../lib/pricingUtils';
 
 const handler = withSessionContext(
     async (req: NextApiRequest, res: NextApiResponse, context: SessionContext): Promise<void> => {
@@ -63,11 +65,15 @@ const handler = withSessionContext(
                     return;
                 }
 
+                const fullBooking = await fetchBookingWithEquipmentLists(bookingId).then(toBooking);
+                const priceSnapshot = computePriceSummary(fullBooking);
+
                 await logChangeToBooking(
                     context.currentUser,
                     bookingId,
                     booking.name,
                     BookingChangelogEntryType.EQUIPMENTLIST,
+                    priceSnapshot,
                 );
 
                 await deleteEquipmentList(equipmentListId)
@@ -110,22 +116,28 @@ const handler = withSessionContext(
                             hasListChanges(existingList.listEntries, newList.listEntries) ||
                             hasChangesInListHeadings
                         ) {
+                            const fullBooking = await fetchBookingWithEquipmentLists(bookingId).then(toBooking);
+                            const priceSnapshot = computePriceSummary(fullBooking);
                             await logChangeToBooking(
                                 context.currentUser,
                                 bookingId,
                                 booking.name,
                                 BookingChangelogEntryType.EQUIPMENTLIST,
+                                priceSnapshot,
                             );
                         }
 
                         // Check if the rental status has changed
                         if (newList.rentalStatus !== undefined && newList.rentalStatus !== existingList?.rentalStatus) {
+                            const fullBooking = await fetchBookingWithEquipmentLists(bookingId).then(toBooking);
+                            const priceSnapshot = computePriceSummary(fullBooking);
                             await logRentalStatusChangeToBooking(
                                 context.currentUser,
                                 bookingId,
                                 booking.name,
                                 newList.name ?? existingList?.name,
                                 newList.rentalStatus ?? null,
+                                priceSnapshot,
                             );
                         }
 

--- a/src/pages/api/bookings/[bookingId]/equipmentLists/index.ts
+++ b/src/pages/api/bookings/[bookingId]/equipmentLists/index.ts
@@ -13,9 +13,11 @@ import {
 } from '../../../../../lib/db-access/equipmentList';
 import { SessionContext, withSessionContext } from '../../../../../lib/sessionContext';
 import { fetchBooking } from '../../../../../lib/db-access';
+import { fetchBookingWithEquipmentLists } from '../../../../../lib/db-access/booking';
 import { toBooking } from '../../../../../lib/mappers/booking';
 import { Status } from '../../../../../models/enums/Status';
 import { logChangeToBooking, BookingChangelogEntryType } from '../../../../../lib/changelogUtils';
+import { computePriceSummary } from '../../../../../lib/pricingUtils';
 
 const handler = withSessionContext(
     async (req: NextApiRequest, res: NextApiResponse, context: SessionContext): Promise<void> => {
@@ -49,11 +51,14 @@ const handler = withSessionContext(
 
                 await insertEquipmentList(req.body.equipmentList, bookingId)
                     .then(async (result) => {
+                        const fullBooking = await fetchBookingWithEquipmentLists(bookingId).then(toBooking);
+                        const priceSnapshot = computePriceSummary(fullBooking);
                         await logChangeToBooking(
                             context.currentUser,
                             bookingId,
                             booking.name,
                             BookingChangelogEntryType.EQUIPMENTLIST,
+                            priceSnapshot,
                         ).then(() => res.status(200).json(result));
                     })
                     .catch((err) => res.status(500).json({ statusCode: 500, message: err.message }));

--- a/src/pages/api/bookings/[bookingId]/index.ts
+++ b/src/pages/api/bookings/[bookingId]/index.ts
@@ -25,6 +25,8 @@ import {
     fetchBookingWithUser,
     fetchBookingWithEquipmentLists,
 } from '../../../../lib/db-access/booking';
+import { toBooking } from '../../../../lib/mappers/booking';
+import { BookingPriceSummary, computePriceSummary } from '../../../../lib/pricingUtils';
 import { SessionContext, withSessionContext } from '../../../../lib/sessionContext';
 import { PaymentStatus } from '../../../../models/enums/PaymentStatus';
 import { Role } from '../../../../models/enums/Role';
@@ -65,7 +67,7 @@ const handler = withSessionContext(
                 }
 
                 if (req.query.reason === undefined) {
-                    respondWithCustomErrorMessage(res, "reason is missing from query parameters")
+                    respondWithCustomErrorMessage(res, 'reason is missing from query parameters');
                 }
 
                 const reason = String(req.query.reason);
@@ -97,7 +99,10 @@ const handler = withSessionContext(
 
                 await updateBooking(bookingId, updatedBooking)
                     .then(async (result) => {
-                        await logChangesToBooking(booking, updatedBooking, context.currentUser);
+                        const updatedBookingWithPrices =
+                            await fetchBookingWithEquipmentLists(bookingId).then(toBooking);
+                        const priceSnapshot = computePriceSummary(updatedBookingWithPrices);
+                        await logChangesToBooking(booking, updatedBooking, context.currentUser, priceSnapshot);
 
                         res.status(200).json(result);
                     })
@@ -134,33 +139,40 @@ const logChangesToBooking = async (
     booking: IBookingObjectionModel,
     newBooking: Partial<BookingObjectionModel>,
     currentUser: CurrentUserInfo,
+    priceSnapshot: BookingPriceSummary,
 ) => {
     const bookingId = booking.id;
 
     // General changes
     if (hasChanges(booking, newBooking, ['status', 'salaryStatus', 'ownerUserId'])) {
-        await logChangeToBooking(currentUser, bookingId, booking.name);
+        await logChangeToBooking(
+            currentUser,
+            bookingId,
+            booking.name,
+            BookingChangelogEntryType.BOOKING,
+            priceSnapshot,
+        );
     }
 
     // Check for status changes
     const newStatus = booking.status !== newBooking.status ? newBooking.status : undefined;
 
     if (newStatus !== null && newStatus !== undefined) {
-        await logStatusChangeToBooking(currentUser, bookingId, booking.name, newStatus);
+        await logStatusChangeToBooking(currentUser, bookingId, booking.name, newStatus, priceSnapshot);
     }
 
     // Check for salary changes
     const newSalaryStatus = booking.salaryStatus !== newBooking.salaryStatus ? newBooking.salaryStatus : undefined;
 
     if (newSalaryStatus !== undefined) {
-        await logSalaryStatusChangeToBooking(currentUser, bookingId, booking.name, newSalaryStatus);
+        await logSalaryStatusChangeToBooking(currentUser, bookingId, booking.name, newSalaryStatus, priceSnapshot);
     }
 
     // Check for payment status changes
     const newPaymentStatus = booking.paymentStatus !== newBooking.paymentStatus ? newBooking.paymentStatus : undefined;
 
     if (newPaymentStatus !== null && newPaymentStatus !== undefined) {
-        await logPaymentStatusChangeToBooking(currentUser, bookingId, booking.name, newPaymentStatus);
+        await logPaymentStatusChangeToBooking(currentUser, bookingId, booking.name, newPaymentStatus, priceSnapshot);
     }
 
     // Check for owner changes
@@ -177,6 +189,7 @@ const logChangesToBooking = async (
             booking.name,
             booking.ownerUser?.name ?? null,
             newOwnerUser?.name,
+            priceSnapshot,
         );
     }
 
@@ -185,7 +198,13 @@ const logChangesToBooking = async (
         newBooking.equipmentLists &&
         hasListChanges(booking.equipmentLists, newBooking.equipmentLists, ['rentalStatus'])
     ) {
-        logChangeToBooking(currentUser, bookingId, booking.name, BookingChangelogEntryType.EQUIPMENTLIST);
+        logChangeToBooking(
+            currentUser,
+            bookingId,
+            booking.name,
+            BookingChangelogEntryType.EQUIPMENTLIST,
+            priceSnapshot,
+        );
     }
 
     // Check for equipment-list rental status changes
@@ -208,6 +227,7 @@ const logChangesToBooking = async (
                 booking.name,
                 list.name ?? getExistingEquipmentListWithId(list.id)?.name,
                 list.rentalStatus ?? null,
+                priceSnapshot,
             ),
         );
     }

--- a/src/pages/api/bookings/[bookingId]/timeEstimate/[timeEstimateId].ts
+++ b/src/pages/api/bookings/[bookingId]/timeEstimate/[timeEstimateId].ts
@@ -16,6 +16,9 @@ import {
 import { Status } from '../../../../../models/enums/Status';
 import { logChangeToBooking, BookingChangelogEntryType, hasChanges } from '../../../../../lib/changelogUtils';
 import { TimeEstimateObjectionModel } from '../../../../../models/objection-models';
+import { fetchBookingWithEquipmentLists } from '../../../../../lib/db-access/booking';
+import { toBooking } from '../../../../../lib/mappers/booking';
+import { computePriceSummary } from '../../../../../lib/pricingUtils';
 
 const handler = withSessionContext(
     async (req: NextApiRequest, res: NextApiResponse, context: SessionContext): Promise<void> => {
@@ -46,11 +49,14 @@ const handler = withSessionContext(
                 }
                 await deleteTimeEstimate(timeEstimateId)
                     .then(async (result) => {
+                        const fullBooking = await fetchBookingWithEquipmentLists(bookingId).then(toBooking);
+                        const priceSnapshot = computePriceSummary(fullBooking);
                         await logChangeToBooking(
                             context.currentUser,
                             bookingId,
                             booking.name,
                             BookingChangelogEntryType.TIMEESTIMATE,
+                            priceSnapshot,
                         ).then(() => res.status(200).json(result));
                     })
                     .catch((error) => respondWithCustomErrorMessage(res, error.message));
@@ -75,11 +81,14 @@ const handler = withSessionContext(
                         const existingTimeEstimate = booking.timeEstimates?.find((l) => l.id === newTimeEstimate.id);
 
                         if (!existingTimeEstimate || hasChanges(existingTimeEstimate, newTimeEstimate)) {
+                            const fullBooking = await fetchBookingWithEquipmentLists(bookingId).then(toBooking);
+                            const priceSnapshot = computePriceSummary(fullBooking);
                             await logChangeToBooking(
                                 context.currentUser,
                                 bookingId,
                                 booking.name,
                                 BookingChangelogEntryType.TIMEESTIMATE,
+                                priceSnapshot,
                             );
                         }
 

--- a/src/pages/api/bookings/[bookingId]/timeEstimate/index.ts
+++ b/src/pages/api/bookings/[bookingId]/timeEstimate/index.ts
@@ -1,6 +1,7 @@
 import { NextApiRequest, NextApiResponse } from 'next';
 import { fetchBooking, fetchTimeEstimatesByBookingId } from '../../../../../lib/db-access';
 import { insertTimeEstimate, validateTimeEstimateObjectionModel } from '../../../../../lib/db-access/timeEstimate';
+import { fetchBookingWithEquipmentLists } from '../../../../../lib/db-access/booking';
 import {
     respondWithAccessDeniedResponse,
     respondWithCustomErrorMessage,
@@ -13,6 +14,7 @@ import { Role } from '../../../../../models/enums/Role';
 import { toBooking } from '../../../../../lib/mappers/booking';
 import { Status } from '../../../../../models/enums/Status';
 import { logChangeToBooking, BookingChangelogEntryType } from '../../../../../lib/changelogUtils';
+import { computePriceSummary } from '../../../../../lib/pricingUtils';
 
 const handler = withSessionContext(
     async (req: NextApiRequest, res: NextApiResponse, context: SessionContext): Promise<void> => {
@@ -43,11 +45,14 @@ const handler = withSessionContext(
                 }
                 await insertTimeEstimate(req.body.timeEstimate)
                     .then(async (result) => {
+                        const fullBooking = await fetchBookingWithEquipmentLists(bookingId).then(toBooking);
+                        const priceSnapshot = computePriceSummary(fullBooking);
                         await logChangeToBooking(
                             context.currentUser,
                             bookingId,
                             booking.name,
                             BookingChangelogEntryType.TIMEESTIMATE,
+                            priceSnapshot,
                         ).then(() => res.status(200).json(result));
                     })
                     .catch((error) => respondWithCustomErrorMessage(res, error.message));

--- a/src/pages/api/bookings/[bookingId]/timeReport/[timeReportId].ts
+++ b/src/pages/api/bookings/[bookingId]/timeReport/[timeReportId].ts
@@ -16,6 +16,9 @@ import {
 import { Status } from '../../../../../models/enums/Status';
 import { logChangeToBooking, BookingChangelogEntryType, hasChanges } from '../../../../../lib/changelogUtils';
 import { TimeReportObjectionModel } from '../../../../../models/objection-models/TimeReportObjectionModel';
+import { fetchBookingWithEquipmentLists } from '../../../../../lib/db-access/booking';
+import { toBooking } from '../../../../../lib/mappers/booking';
+import { computePriceSummary } from '../../../../../lib/pricingUtils';
 
 const handler = withSessionContext(
     async (req: NextApiRequest, res: NextApiResponse, context: SessionContext): Promise<void> => {
@@ -46,11 +49,14 @@ const handler = withSessionContext(
                 }
                 await deleteTimeReport(timeReportId)
                     .then(async (result) => {
+                        const fullBooking = await fetchBookingWithEquipmentLists(bookingId).then(toBooking);
+                        const priceSnapshot = computePriceSummary(fullBooking);
                         await logChangeToBooking(
                             context.currentUser,
                             bookingId,
                             booking.name,
                             BookingChangelogEntryType.TIMEREPORT,
+                            priceSnapshot,
                         ).then(() => res.status(200).json(result));
                     })
                     .catch((error) => respondWithCustomErrorMessage(res, error.message));
@@ -75,11 +81,14 @@ const handler = withSessionContext(
                         const existingTimeReport = booking.timeReports?.find((l) => l.id === newTimeReport.id);
 
                         if (!existingTimeReport || hasChanges(existingTimeReport, newTimeReport)) {
+                            const fullBooking = await fetchBookingWithEquipmentLists(bookingId).then(toBooking);
+                            const priceSnapshot = computePriceSummary(fullBooking);
                             await logChangeToBooking(
                                 context.currentUser,
                                 bookingId,
                                 booking.name,
                                 BookingChangelogEntryType.TIMEREPORT,
+                                priceSnapshot,
                             );
                         }
 

--- a/src/pages/api/bookings/[bookingId]/timeReport/index.ts
+++ b/src/pages/api/bookings/[bookingId]/timeReport/index.ts
@@ -1,6 +1,7 @@
 import { NextApiRequest, NextApiResponse } from 'next';
 import { fetchBooking, fetchTimeReportsByBookingId } from '../../../../../lib/db-access';
 import { insertTimeReport, validateTimeReportObjectionModel } from '../../../../../lib/db-access/timeReport';
+import { fetchBookingWithEquipmentLists } from '../../../../../lib/db-access/booking';
 import {
     respondWithAccessDeniedResponse,
     respondWithCustomErrorMessage,
@@ -13,6 +14,7 @@ import { Role } from '../../../../../models/enums/Role';
 import { toBooking } from '../../../../../lib/mappers/booking';
 import { Status } from '../../../../../models/enums/Status';
 import { logChangeToBooking, BookingChangelogEntryType } from '../../../../../lib/changelogUtils';
+import { computePriceSummary } from '../../../../../lib/pricingUtils';
 
 const handler = withSessionContext(
     async (req: NextApiRequest, res: NextApiResponse, context: SessionContext): Promise<void> => {
@@ -43,11 +45,14 @@ const handler = withSessionContext(
                 }
                 await insertTimeReport(req.body.timeReport)
                     .then(async (result) => {
+                        const fullBooking = await fetchBookingWithEquipmentLists(bookingId).then(toBooking);
+                        const priceSnapshot = computePriceSummary(fullBooking);
                         await logChangeToBooking(
                             context.currentUser,
                             bookingId,
                             booking.name,
                             BookingChangelogEntryType.TIMEREPORT,
+                            priceSnapshot,
                         ).then(() => res.status(200).json(result));
                     })
                     .catch((error) => respondWithCustomErrorMessage(res, error.message));

--- a/src/pages/api/bookings/index.ts
+++ b/src/pages/api/bookings/index.ts
@@ -7,9 +7,15 @@ import {
 } from '../../../lib/apiResponses';
 import { BookingChangelogEntryType, logChangeToBooking } from '../../../lib/changelogUtils';
 import { fetchBookings } from '../../../lib/db-access';
-import { insertBooking, validateBookingObjectionModel } from '../../../lib/db-access/booking';
+import {
+    fetchBookingWithEquipmentLists,
+    insertBooking,
+    validateBookingObjectionModel,
+} from '../../../lib/db-access/booking';
 import { SessionContext, withSessionContext } from '../../../lib/sessionContext';
 import { Role } from '../../../models/enums/Role';
+import { toBooking } from '../../../lib/mappers/booking';
+import { computePriceSummary } from '../../../lib/pricingUtils';
 
 const handler = withSessionContext(
     async (req: NextApiRequest, res: NextApiResponse, context: SessionContext): Promise<void> => {
@@ -30,12 +36,17 @@ const handler = withSessionContext(
                 }
 
                 await insertBooking(req.body.booking)
-                    .then((result) => {
+                    .then(async (result) => {
+                        const priceSummary = await fetchBookingWithEquipmentLists(result.id)
+                        .then(toBooking)
+                        .then(computePriceSummary);
+                        
                         logChangeToBooking(
                             context.currentUser,
                             result.id,
                             result.name,
                             BookingChangelogEntryType.CREATE,
+                            priceSummary,
                         ).then(() => res.status(200).json(result));
                     })
                     .catch((error) => respondWithCustomErrorMessage(res, error.message));

--- a/src/pages/api/bookings/paymentStatus/[bookingId].ts
+++ b/src/pages/api/bookings/paymentStatus/[bookingId].ts
@@ -2,6 +2,8 @@ import { NextApiRequest, NextApiResponse } from 'next';
 import { respondWithAccessDeniedResponse, respondWithInvalidMethodResponse } from '../../../../lib/apiResponses';
 import { SessionContext, withSessionContext } from '../../../../lib/sessionContext';
 import { fetchBookingWithEquipmentLists, updateBooking } from '../../../../lib/db-access/booking';
+import { toBooking } from '../../../../lib/mappers/booking';
+import { computePriceSummary } from '../../../../lib/pricingUtils';
 import { PaymentStatus } from '../../../../models/enums/PaymentStatus';
 import { Role } from '../../../../models/enums/Role';
 import { logPaymentStatusChangeToBooking } from '../../../../lib/changelogUtils';
@@ -38,7 +40,16 @@ const handler = withSessionContext(
 
                 await updateBooking(bookingId, { paymentStatus: status })
                     .then(async (result) => {
-                        await logPaymentStatusChangeToBooking(context.currentUser, bookingId, booking.name, status);
+                        const updatedBookingWithPrices =
+                            await fetchBookingWithEquipmentLists(bookingId).then(toBooking);
+                        const priceSnapshot = computePriceSummary(updatedBookingWithPrices);
+                        await logPaymentStatusChangeToBooking(
+                            context.currentUser,
+                            bookingId,
+                            booking.name,
+                            status,
+                            priceSnapshot,
+                        );
 
                         res.status(200).json(result);
                     })

--- a/src/pages/api/sendMessage/toBookingOwners.ts
+++ b/src/pages/api/sendMessage/toBookingOwners.ts
@@ -6,6 +6,9 @@ import { onlyUniqueById } from '../../../lib/utils';
 import { toUser } from '../../../lib/mappers/user';
 import { sendSlackMessageToUsersRegardingBookings } from '../../../lib/slack';
 import { logMessageSentToBookingOwner } from '../../../lib/changelogUtils';
+import { fetchBookingWithEquipmentLists } from '../../../lib/db-access/booking';
+import { toBooking } from '../../../lib/mappers/booking';
+import { computePriceSummary } from '../../../lib/pricingUtils';
 
 const handler = withSessionContext(
     async (req: NextApiRequest, res: NextApiResponse, context: SessionContext): Promise<void> => {
@@ -49,7 +52,11 @@ const handler = withSessionContext(
 
             await Promise.all(
                 bookings.map((booking) => {
-                    logMessageSentToBookingOwner(context.currentUser, booking.id, booking.ownerUser.name);
+                    fetchBookingWithEquipmentLists(booking.id)
+                        .then(toBooking)
+                        .then(computePriceSummary)
+                        .then((priceSummary) => 
+                            logMessageSentToBookingOwner(context.currentUser, booking.id, booking.ownerUser.name, priceSummary));
                 }),
             );
 

--- a/src/pages/bookings/[id]/index.tsx
+++ b/src/pages/bookings/[id]/index.tsx
@@ -44,16 +44,9 @@ import { toBooking } from '../../../lib/mappers/booking';
 import { useNotifications } from '../../../lib/useNotifications';
 import { Status } from '../../../models/enums/Status';
 import { PaymentStatus } from '../../../models/enums/PaymentStatus';
-import ChangelogCard from '../../../components/ChangelogCard';
-import {
-    addVAT,
-    formatCurrency,
-    getBookingPrice,
-    getEquipmentListPrice,
-    getTotalTimeEstimatesPrice,
-    getTotalTimeReportsPrice,
-    getVAT,
-} from '../../../lib/pricingUtils';
+import BookingChangelogCard from '../../../components/bookings/BookingChangelogCard';
+import BookingPriceSummaryDisplay from '../../../components/bookings/BookingPriceSummary';
+import { computePriceSummary, getEquipmentListPrice } from '../../../lib/pricingUtils';
 import BookingRentalStatusButton from '../../../components/bookings/BookingRentalStatusButton';
 import { PartialDeep } from 'type-fest';
 import { formatDateForForm, toBookingViewModel } from '../../../lib/datetimeUtils';
@@ -63,7 +56,6 @@ import ToggleCoOwnerButton from '../../../components/bookings/ToggleCoOwnerButto
 import ConfirmModal from '../../../components/utils/ConfirmModal';
 import BookingInfoSection from '../../../components/bookings/BookingInfoSection';
 import FilesCard from '../../../components/bookings/FilesCard';
-import currency from 'currency.js';
 import PreviousBookingsCard from '../../../components/bookings/PreviousBookingsCard';
 import { BookingType } from '../../../models/enums/BookingType';
 import CalendarWorkersCard from '../../../components/bookings/CalendarWorkersCard';
@@ -75,14 +67,15 @@ export const getServerSideProps = useUserWithDefaultAccessAndWithSettings();
 type Props = { user: CurrentUserInfo; globalSettings: KeyValue[] };
 
 const BookingPage: React.FC<Props> = ({ user: currentUser, globalSettings }: Props) => {
-    const { showSaveSuccessNotification, showSaveFailedNotification, showGeneralDangerMessage, showErrorMessage } = useNotifications();
+    const { showSaveSuccessNotification, showSaveFailedNotification, showGeneralDangerMessage, showErrorMessage } =
+        useNotifications();
 
     const [showConfirmReadyForCashPaymentModal, setShowConfirmReadyForCashPaymentModal] = useState(false);
     const [showConfirmPaidModal, setShowConfirmPaidModal] = useState(false);
     const [adminEditModeOverrideEnabled, setAdminEditModeOverrideEnabled] = useState(false);
     const [alwaysShowRentalControls, setAlwaysShowRentalControls] = useState(false);
     const [showDeleteModal, setShowDeleteModal] = useState(false);
-    const [deleteReason, setDeleteReason] = useState("");
+    const [deleteReason, setDeleteReason] = useState('');
     const [showCancelModal, setShowCancelModal] = useState(false);
 
     // Edit booking
@@ -196,7 +189,6 @@ const BookingPage: React.FC<Props> = ({ user: currentUser, globalSettings }: Pro
 
     const readonly =
         (currentUser.role === Role.READONLY || booking.status === Status.DONE) && !adminEditModeOverrideEnabled;
-    const timeReportExists = booking.timeReports && booking.timeReports.length > 0;
 
     return (
         <Layout title={pageTitle} fixedWidth={true} currentUser={currentUser} globalSettings={globalSettings}>
@@ -364,14 +356,13 @@ const BookingPage: React.FC<Props> = ({ user: currentUser, globalSettings }: Pro
                         Om bokningen inte skapats av misstag kan det vara lämpligare att ställa in den istället.
                     </p>
                     <Form.Control
-                        type='text'
-                        className='mb-0'
-                        placeholder={"Anledning till att bokningen tas bort"}
+                        type="text"
+                        className="mb-0"
+                        placeholder={'Anledning till att bokningen tas bort'}
                         defaultValue={deleteReason}
                         onChange={(e) => setDeleteReason(e.target.value)}
                         autoFocus
                     />
-
                 </ConfirmModal>
             </Header>
 
@@ -412,102 +403,14 @@ const BookingPage: React.FC<Props> = ({ user: currentUser, globalSettings }: Pro
                     ) : null}
                     <Card className="mb-3">
                         <Card.Header>Prisinformation (ink. moms)</Card.Header>
-                        <ListGroup variant="flush">
-                            {booking.equipmentLists?.map((list) => (
-                                <ListGroup.Item className="d-flex" key={list.id}>
-                                    <span className="flex-grow-1">{list.name}</span>
-                                    <span>{formatCurrency(addVAT(getEquipmentListPrice(list)))}</span>
-                                </ListGroup.Item>
-                            ))}
-                            <ListGroup.Item className="d-flex">
-                                <span className="flex-grow-1">Estimerad personalkostnad</span>
-                                <span>{formatCurrency(addVAT(getTotalTimeEstimatesPrice(booking.timeEstimates)))}</span>
-                            </ListGroup.Item>
-                            <ListGroup.Item className="d-flex">
-                                <strong className="flex-grow-1">Pris med estimerad personalkostnad</strong>
-                                <strong>{formatCurrency(addVAT(getBookingPrice(booking, true, true)))}</strong>
-                            </ListGroup.Item>
-                            <ListGroup.Item className="d-flex">
-                                <em className="flex-grow-1 ps-4">varav moms (25%)</em>
-                                <em>{formatCurrency(getVAT(getBookingPrice(booking, true, true)))}</em>
-                            </ListGroup.Item>
-                            {timeReportExists ? (
-                                <>
-                                    <ListGroup.Item className="d-flex">
-                                        <span className="flex-grow-1">Faktisk personalkostnad</span>
-                                        <span>
-                                            {formatCurrency(addVAT(getTotalTimeReportsPrice(booking.timeReports)))}
-                                        </span>
-                                    </ListGroup.Item>
-                                    <ListGroup.Item className="d-flex">
-                                        <strong className="flex-grow-1">Pris med faktisk personalkostnad</strong>
-                                        <strong>{formatCurrency(addVAT(getBookingPrice(booking, false, true)))}</strong>
-                                    </ListGroup.Item>
-                                    <ListGroup.Item className="d-flex">
-                                        <em className="flex-grow-1 ps-4">varav moms (25%)</em>
-                                        <em>{formatCurrency(getVAT(getBookingPrice(booking, false, true)))}</em>
-                                    </ListGroup.Item>
-                                    <ListGroup.Item className="d-flex">
-                                        <span className="flex-grow-1">Skillnad mot estimerad personalkostnad</span>
-                                        <span>
-                                            {formatCurrency(
-                                                addVAT(
-                                                    getBookingPrice(booking, false, true).subtract(
-                                                        getBookingPrice(booking, true, true),
-                                                    ),
-                                                ),
-                                                true,
-                                            )}
-                                        </span>
-                                    </ListGroup.Item>
-                                </>
-                            ) : null}
-                            {booking.fixedPrice !== null && booking.fixedPrice !== undefined ? (
-                                <>
-                                    <ListGroup.Item className="d-flex">
-                                        <strong className="flex-grow-1">Fast pris</strong>
-                                        <strong>{formatCurrency(addVAT(booking.fixedPrice))}</strong>
-                                    </ListGroup.Item>
-                                    <ListGroup.Item className="d-flex">
-                                        <em className="flex-grow-1 ps-4">varav moms (25%)</em>
-                                        <em>{formatCurrency(getVAT(booking.fixedPrice))}</em>
-                                    </ListGroup.Item>
-                                    {timeReportExists ? (
-                                        <ListGroup.Item className="d-flex">
-                                            <span className="flex-grow-1">
-                                                Skillnad mot pris med faktisk personalkostnad
-                                            </span>
-                                            <span>
-                                                {formatCurrency(
-                                                    addVAT(
-                                                        currency(booking.fixedPrice).subtract(
-                                                            getBookingPrice(booking, false, true),
-                                                        ),
-                                                    ),
-                                                    true,
-                                                )}
-                                            </span>
-                                        </ListGroup.Item>
-                                    ) : (
-                                        <ListGroup.Item className="d-flex">
-                                            <span className="flex-grow-1">
-                                                Skillnad mot pris med estimerad personalkostnad
-                                            </span>
-                                            <span>
-                                                {formatCurrency(
-                                                    addVAT(
-                                                        currency(booking.fixedPrice).subtract(
-                                                            getBookingPrice(booking, true, true),
-                                                        ),
-                                                    ),
-                                                    true,
-                                                )}
-                                            </span>
-                                        </ListGroup.Item>
-                                    )}
-                                </>
-                            ) : null}
-                        </ListGroup>
+                        <BookingPriceSummaryDisplay
+                            bookingPriceSummary={computePriceSummary(booking)}
+                            equipmentListDetails={booking.equipmentLists?.map((l) => ({
+                                id: l.id,
+                                name: l.name,
+                                price: getEquipmentListPrice(l),
+                            }))}
+                        />
                     </Card>
                     <Card className="mb-3">
                         <Card.Header>Bokningsinformation</Card.Header>
@@ -592,7 +495,7 @@ const BookingPage: React.FC<Props> = ({ user: currentUser, globalSettings }: Pro
                         readonly={readonly}
                     />
                     <PreviousBookingsCard hogiaId={booking.invoiceHogiaId} bookingId={booking.id} />
-                    <ChangelogCard changelog={booking.changelog ?? []} />
+                    <BookingChangelogCard changelog={booking.changelog ?? []} />
                 </Col>
             </Row>
         </Layout>

--- a/src/pages/equipment/[id]/index.tsx
+++ b/src/pages/equipment/[id]/index.tsx
@@ -17,7 +17,7 @@ import { faPen } from '@fortawesome/free-solid-svg-icons';
 import EquipmentCalendar from '../../../components/equipment/EquipmentCalendar';
 import EquipmentBookings from '../../../components/equipment/EquipmentBookings';
 import EquipmentTagDisplay from '../../../components/utils/EquipmentTagDisplay';
-import ChangelogCard from '../../../components/ChangelogCard';
+import EquipmentChangelogCard from '../../../components/EquipmentChangelogCard';
 import MarkdownCard from '../../../components/MarkdownCard';
 import { KeyValue } from '../../../models/interfaces/KeyValue';
 import { getPricePlanName, getResponseContentOrError } from '../../../lib/utils';
@@ -182,7 +182,7 @@ const UserPage: React.FC<Props> = ({ user: currentUser, globalSettings }: Props)
                         </ListGroup>
                     </Card>
 
-                    <ChangelogCard changelog={equipment.changelog ?? []} />
+                    <EquipmentChangelogCard changelog={equipment.changelog ?? []} />
                 </Col>
                 <Col xl={8}>
                     <MarkdownCard

--- a/src/pages/users/import.tsx
+++ b/src/pages/users/import.tsx
@@ -355,21 +355,21 @@ const UserCsvImportPage: React.FC<Props> = ({ user: currentUser, globalSettings 
                 },
                 getContentOverride: (row) => {
                     const isSkipped = row.isValid && users.some((u) => u.name === row.name);
-                    if (!row.isValid) return <Badge variant="danger">Ogiltig rad</Badge>;
-                    if (isSkipped) return <Badge variant="secondary">Finns redan</Badge>;
+                    if (!row.isValid) return <Badge bg="danger">Ogiltig rad</Badge>;
+                    if (isSkipped) return <Badge bg="secondary">Finns redan</Badge>;
                     const isUsernameConflict =
                         row.username.length > 0 &&
                         (duplicateUsernamesInCsv.includes(row.username) ||
                             usernamesTakenByExistingUsers.includes(row.username));
                     if (isUsernameConflict)
                         return (
-                            <Badge variant="danger">
+                            <Badge bg="danger">
                                 {duplicateUsernamesInCsv.includes(row.username)
                                     ? 'Dublett användarnamn'
                                     : 'Användarnamn upptaget'}
                             </Badge>
                         );
-                    return <Badge variant="success">Importeras</Badge>;
+                    return <Badge bg="success">Importeras</Badge>;
                 },
             },
         ],


### PR DESCRIPTION
Include price in change-log entries for bookings.

Both equipmentPrice, timeEstimatePrice, timeReportPrice, and fixed price are stored. Pricing logic has been refactored to generate an object with all these properties and have a separate function to select the correct price to show. This allows us to reuse the same code for showing the current price as well as historical prices. Note: for historical prices all equipment lists are totaled into a single row.

When a database operation modifies a booking the full booking is read back and the price calculated. This is probably not the most efficient way to do this, but it is quite straightforward, easy to understand, and quite robust. Unfortunately this means that for most booking-related database operations we now (instead of just writing the new state):

1. Read the old state of the booking (to figure out what has changed for the changelog)
2. Write the new state
3. Read the new state of the booking (to figure out the new price)

**Changelog card:**
<img width="447" height="370" alt="image" src="https://github.com/user-attachments/assets/c7d28e63-1721-497a-9517-05c7d2709ca7" />

**Changelog modal:**
<img width="841" height="487" alt="image" src="https://github.com/user-attachments/assets/f58b8ec5-99a9-4025-9e10-2ced72dee2f2" />
(Note the first/lowest changelog entry, which were made before this update and therefore is shown without price)

**Changelog entry details modal:**
<img width="913" height="576" alt="image" src="https://github.com/user-attachments/assets/9db1eb8e-d9c8-4c81-b1dc-28b1d4a94870" />

Since I vibe-coded most of this and this pull request touches some of the more critical systems (price calculations) we should probably look over some parts of this code in detail together.