### PR TITLE
Feature: Add discount presents

### DIFF
--- a/knex/seeds/mock.js
+++ b/knex/seeds/mock.js
@@ -2089,6 +2089,13 @@ export async function seed(knex) {
             updated: getVarianceDateString(100),
             value: '',
         },
+        {
+            key: 'booking.discountPresets',
+            note: 'Förinställda rabattvärden för utrustningslistor, som JSON-lista med objekt med "label" (sträng) och "value" (heltal 0-100).',
+            created: getVarianceDateString(-100),
+            updated: getVarianceDateString(100),
+            value: '[{"label": "Ingen rabatt", "value": 0}, {"label": "Student", "value": 20}, {"label": "Spex", "value": 50}]',
+        },
     ]);
 
     await knex('Customer')

--- a/knex/seeds/mock.js
+++ b/knex/seeds/mock.js
@@ -2094,7 +2094,7 @@ export async function seed(knex) {
             note: 'Förinställda rabattvärden för utrustningslistor, som JSON-lista med objekt med "label" (sträng) och "value" (heltal 0-100).',
             created: getVarianceDateString(-100),
             updated: getVarianceDateString(100),
-            value: '[{"label": "Ingen rabatt", "value": 0}, {"label": "Student", "value": 20}, {"label": "Spex", "value": 50}]',
+            value: '[{"label": "Ingen rabatt", "value": 0}, {"label": "Student", "value": 25}, {"label": "Spex", "value": 50}]',
         },
     ]);
 

--- a/src/components/bookings/equipmentLists/EditDiscountModal.tsx
+++ b/src/components/bookings/equipmentLists/EditDiscountModal.tsx
@@ -1,0 +1,97 @@
+import React, { useState } from 'react';
+import { Alert, Button, Form, InputGroup, Modal } from 'react-bootstrap';
+import { KeyValue } from '../../../models/interfaces/KeyValue';
+import { getGlobalSetting } from '../../../lib/utils';
+
+type DiscountPreset = {
+    label: string;
+    value: number;
+};
+
+type Props = {
+    show: boolean;
+    hide: () => void;
+    onSubmit: (value: number) => void;
+    discountPercentage: number;
+    globalSettings: KeyValue[];
+};
+
+const isValidDiscount = (text: string) => {
+    const n = parseInt(text, 10);
+    return !isNaN(n) && n >= 0 && n <= 100;
+};
+
+const EditDiscountModal: React.FC<Props> = ({ show, hide, onSubmit, discountPercentage, globalSettings }: Props) => {
+    const [value, setValue] = useState(discountPercentage.toString());
+
+    let presets: DiscountPreset[] = [];
+    let hasPresetError = false;
+    try {
+        presets = JSON.parse(getGlobalSetting('booking.discountPresets', globalSettings, '[]')) as DiscountPreset[];
+    } catch {
+        hasPresetError = true;
+    }
+
+    const onCancel = () => {
+        setValue(discountPercentage.toString());
+        hide();
+    };
+
+    const onConfirm = () => {
+        hide();
+        onSubmit(Math.min(100, Math.max(0, parseInt(value, 10))));
+    };
+
+    return (
+        <Modal show={show} onHide={onCancel} size="sm" backdrop="static">
+            <Modal.Header closeButton>
+                <Modal.Title>Redigera rabatt</Modal.Title>
+            </Modal.Header>
+            <Modal.Body>
+                {hasPresetError ? (
+                    <Alert variant="danger" className="mb-3">
+                        <strong>Fel</strong> Ogiltig JSON i inställningen <code>booking.discountPresets</code>
+                    </Alert>
+                ) : null}
+                {presets.length > 0 ? (
+                    <div className="mb-3">
+                        {presets.map((preset) => (
+                            <Button
+                                key={preset.label}
+                                variant="secondary"
+                                className="d-block w-100 mb-2"
+                                onClick={() => {
+                                    hide();
+                                    onSubmit(preset.value);
+                                }}
+                            >
+                                {preset.label} ({preset.value}%)
+                            </Button>
+                        ))}
+                    </div>
+                ) : null}
+                <hr />
+                <InputGroup>
+                    <Form.Control
+                        type="number"
+                        min={0}
+                        max={100}
+                        value={value}
+                        onChange={(e) => setValue(e.target.value)}
+                    />
+                    <InputGroup.Text>%</InputGroup.Text>
+                </InputGroup>
+            </Modal.Body>
+            <Modal.Footer>
+                <Button variant="secondary" onClick={onCancel}>
+                    Avbryt
+                </Button>
+                <Button variant="primary" onClick={onConfirm} disabled={!isValidDiscount(value)}>
+                    Spara
+                </Button>
+            </Modal.Footer>
+        </Modal>
+    );
+};
+
+export default EditDiscountModal;

--- a/src/components/bookings/equipmentLists/EditDiscountModal.tsx
+++ b/src/components/bookings/equipmentLists/EditDiscountModal.tsx
@@ -21,16 +21,18 @@ const isValidDiscount = (text: string) => {
     return !isNaN(n) && n >= 0 && n <= 100;
 };
 
+const parsePresets = (globalSettings: KeyValue[]) => {
+    try {
+        return JSON.parse(getGlobalSetting('booking.discountPresets', globalSettings, '[]')) as DiscountPreset[];
+    } catch {
+        return null;
+    }
+}
+
 const EditDiscountModal: React.FC<Props> = ({ show, hide, onSubmit, discountPercentage, globalSettings }: Props) => {
     const [value, setValue] = useState(discountPercentage.toString());
 
-    let presets: DiscountPreset[] = [];
-    let hasPresetError = false;
-    try {
-        presets = JSON.parse(getGlobalSetting('booking.discountPresets', globalSettings, '[]')) as DiscountPreset[];
-    } catch {
-        hasPresetError = true;
-    }
+    const presets = parsePresets(globalSettings);
 
     const onCancel = () => {
         setValue(discountPercentage.toString());
@@ -48,12 +50,12 @@ const EditDiscountModal: React.FC<Props> = ({ show, hide, onSubmit, discountPerc
                 <Modal.Title>Redigera rabatt</Modal.Title>
             </Modal.Header>
             <Modal.Body>
-                {hasPresetError ? (
+                {presets === null ? (
                     <Alert variant="danger" className="mb-3">
                         <strong>Fel</strong> Ogiltig JSON i inställningen <code>booking.discountPresets</code>
                     </Alert>
                 ) : null}
-                {presets.length > 0 ? (
+                {presets && presets.length > 0 ? (
                     <div className="mb-3">
                         {presets.map((preset) => (
                             <Button
@@ -95,3 +97,4 @@ const EditDiscountModal: React.FC<Props> = ({ show, hide, onSubmit, discountPerc
 };
 
 export default EditDiscountModal;
+

--- a/src/components/bookings/equipmentLists/EquipmentList.tsx
+++ b/src/components/bookings/equipmentLists/EquipmentList.tsx
@@ -422,6 +422,7 @@ const EquipmentListDisplay: React.FC<Props> = ({
                     disableDelete={otherLists.length === 0}
                     alwaysShowRentalControls={alwaysShowRentalControls}
                     readonly={readonly}
+                    globalSettings={globalSettings}
                 />
             </Card.Header>
 

--- a/src/components/bookings/equipmentLists/EquipmentListHeader.tsx
+++ b/src/components/bookings/equipmentLists/EquipmentListHeader.tsx
@@ -40,7 +40,8 @@ import ConfirmModal from '../../utils/ConfirmModal';
 import BookingReturnalNoteModal from '../BookingReturnalNoteModal';
 import CopyEquipmentListEntriesModal from './CopyEquipmentListEntriesModal';
 import EditEquipmentListDatesModal from './EditEquipmentListDatesModal';
-import EditTextModal from '../../utils/EditTextModal';
+import EditDiscountModal from './EditDiscountModal';
+import { KeyValue } from '../../../models/interfaces/KeyValue';
 import Link from 'next/link';
 
 type Props = {
@@ -70,6 +71,7 @@ type Props = {
     disableDelete: boolean;
     alwaysShowRentalControls: boolean;
     readonly: boolean;
+    globalSettings: KeyValue[];
 };
 
 const EquipmentListHeader: React.FC<Props> = ({
@@ -95,6 +97,7 @@ const EquipmentListHeader: React.FC<Props> = ({
     disableDelete,
     alwaysShowRentalControls,
     readonly,
+    globalSettings,
 }: Props) => {
     const [showEmptyListModal, setShowEmptyListModal] = useState(false);
     const [showDeleteModal, setShowDeleteModal] = useState(false);
@@ -251,26 +254,18 @@ const EquipmentListHeader: React.FC<Props> = ({
                                     <FontAwesomeIcon icon={faPercent} className="me-1 fa-fw" /> Redigera rabatt
                                 </Dropdown.Item>
                                 {showEditDiscountPercentageModal ? (
-                                    <EditTextModal
-                                        text={list.discountPercentage.toString()}
+                                    <EditDiscountModal
+                                        show={showEditDiscountPercentageModal}
+                                        hide={() => setShowEditDiscountPercentageModal(false)}
+                                        discountPercentage={list.discountPercentage}
+                                        globalSettings={globalSettings}
                                         onSubmit={(newDiscountPercentage) => {
                                             saveList({
                                                 ...list,
-                                                discountPercentage: Math.min(
-                                                    100,
-                                                    Math.max(0, parseInt(newDiscountPercentage)),
-                                                ),
+                                                discountPercentage: newDiscountPercentage,
                                             });
                                             setShowEditDiscountPercentageModal(false);
                                         }}
-                                        hide={() => setShowEditDiscountPercentageModal(false)}
-                                        show={showEditDiscountPercentageModal}
-                                        modalTitle={'Redigera rabatt'}
-                                        modalConfirmText={'Spara'}
-                                        modalSize="sm"
-                                        textarea={false}
-                                        textFieldSuffix="%"
-                                        textIsValid={(text) => !isNaN(parseInt(text))}
                                     />
                                 ) : null}
                                 <CopyEquipmentListEntriesModal


### PR DESCRIPTION
Add presets for equipment-list percentage discounts which are shown as "quick buttons" for the user. Presets are configured as JSON-array in the settings (like accounts or sidebar links).

<img width="504" height="541" alt="image" src="https://github.com/user-attachments/assets/b46b9ab7-579c-4eb8-8d87-dcbce2a7fb42" />
