### PR TITLE
Feature: add categorization of users in user dropdown

### DIFF
--- a/src/components/bookings/BookingForm.tsx
+++ b/src/components/bookings/BookingForm.tsx
@@ -6,6 +6,7 @@ import {
     getAccountKindName,
     getBookingTypeName,
     getLanguageName,
+    getMemberStatusName,
     getPaymentStatusName,
     getPricePlanName,
     getSalaryStatusName,
@@ -21,6 +22,7 @@ import { Status } from '../../models/enums/Status';
 import { AccountKind } from '../../models/enums/AccountKind';
 import { PricePlan } from '../../models/enums/PricePlan';
 import { SalaryStatus } from '../../models/enums/SalaryStatus';
+import { MemberStatus } from '../../models/enums/MemberStatus';
 import { usersFetcher } from '../../lib/fetchers';
 import RequiredIndicator from '../utils/RequiredIndicator';
 import { PaymentStatus } from '../../models/enums/PaymentStatus';
@@ -294,11 +296,26 @@ const BookingForm: React.FC<Props> = ({
                                 defaultValue={booking.ownerUser?.id ?? booking.ownerUserId}
                                 required={isFieldRequired(Status.DRAFT)}
                             >
-                                {users?.sort(nameSortFn).map((user) => (
-                                    <option key={user.id} value={user.id}>
-                                        {user.name}
-                                    </option>
-                                ))}
+                                {[
+                                    MemberStatus.CHEF,
+                                    MemberStatus.AKTIV,
+                                    MemberStatus.RESURS,
+                                    MemberStatus.ASP,
+                                    MemberStatus.GLÖMD
+                                ].map(statusGroup =>
+                                    <optgroup
+                                        key={getMemberStatusName(statusGroup)}
+                                        label={getMemberStatusName(statusGroup)}
+                                    >
+                                        {users
+                                            ?.filter((user) => user.memberStatus === statusGroup)
+                                            ?.sort(nameSortFn).map((user) => (
+                                                <option key={user.id} value={user.id}>
+                                                    {user.name}
+                                                </option>
+                                            ))}
+                                    </optgroup>
+                                )}
                             </Form.Select>
                         ) : (
                             <ActivityIndicator />

--- a/src/components/bookings/timeReport/TimeReportModal.tsx
+++ b/src/components/bookings/timeReport/TimeReportModal.tsx
@@ -1,7 +1,7 @@
 import React, { FormEvent } from 'react';
 import { Modal, Col, Form, Row, InputGroup, Button } from 'react-bootstrap';
 import { usersFetcher } from '../../../lib/fetchers';
-import { nameSortFn, toIntOrUndefined } from '../../../lib/utils';
+import { getMemberStatusName, nameSortFn, toIntOrUndefined } from '../../../lib/utils';
 import PriceWithVATPreview from '../../utils/PriceWithVATPreview';
 import useSwr from 'swr';
 import RequiredIndicator from '../../utils/RequiredIndicator';
@@ -11,6 +11,7 @@ import { getNextSortIndex } from '../../../lib/sortIndexUtils';
 import { ITimeReportObjectionModel } from '../../../models/objection-models';
 import { formatNumberAsCurrency } from '../../../lib/pricingUtils';
 import currency from 'currency.js';
+import { MemberStatus } from '../../../models/enums/MemberStatus';
 
 type Props = {
     booking: BookingViewModel;
@@ -239,11 +240,26 @@ const TimeReportModal: React.FC<Props> = ({
                                     }
                                 >
                                     <option value="">Inte tilldelat</option>
-                                    {users?.sort(nameSortFn).map((user) => (
-                                        <option key={user.id} value={user.id}>
-                                            {user.name}
-                                        </option>
-                                    ))}
+                                    {[
+                                        MemberStatus.CHEF,
+                                        MemberStatus.AKTIV,
+                                        MemberStatus.RESURS,
+                                        MemberStatus.ASP,
+                                        MemberStatus.GLÖMD
+                                    ].map(statusGroup =>
+                                        <optgroup
+                                            key={getMemberStatusName(statusGroup)}
+                                            label={getMemberStatusName(statusGroup)}
+                                        >
+                                            {users
+                                                ?.filter((user) => user.memberStatus === statusGroup)
+                                                ?.sort(nameSortFn).map((user) => (
+                                                    <option key={user.id} value={user.id}>
+                                                        {user.name}
+                                                    </option>
+                                                ))}
+                                        </optgroup>
+                                    )}
                                 </Form.Select>
                             </Form.Group>
                         </Col>


### PR DESCRIPTION
We are starting to get a lot of users now, so I thought it would be really nice to be to have a categorized list of all users in user selection inputs, with the most relevant ones at the top.

Search still works.

See images for examples with fake users, in prod we have even more users (55)

Before:
<img width="407" height="756" alt="2026-05-03-23:06:30" src="https://github.com/user-attachments/assets/30333fa6-9825-48e6-85b9-3870a0f9971f" />

After:
<img width="451" height="796" alt="2026-05-03-23:06:04" src="https://github.com/user-attachments/assets/46009cee-2f2c-4d67-be6f-ee9352e5f045" />