### PR TITLE
Bugfix: change booking tags to adapt to bootstrap 5 css

### DIFF
--- a/src/components/utils/BookingStatusTag.tsx
+++ b/src/components/utils/BookingStatusTag.tsx
@@ -9,7 +9,7 @@ type Props = {
 };
 
 const BookingStatusTag: React.FC<Props> = ({ booking, className }: Props) => (
-    <Badge style={{ backgroundColor: getStatusColor(booking.status) }} className={className}>
+    <Badge bg="dark" style={{ '--badge-color': getStatusColor(booking.status) } as React.CSSProperties} className={className}>
         {getStatusName(booking.status)}
     </Badge>
 );


### PR DESCRIPTION
All the Booking tags had turned blue.

Does use an ugly `as` cast, but it seems like the most reasonable solution atm. We are using the same pattern in `EquipmentTagDisplay` so I suppose we'll fix both at the same time