### PR TITLE
Feature: Improve markdown styling

### DIFF
--- a/src/components/MarkdownCard.module.scss
+++ b/src/components/MarkdownCard.module.scss
@@ -1,0 +1,33 @@
+@use '../style/variables';
+
+.markdownWrapper {
+    overflow-x: auto;
+    table {
+        border-collapse: collapse;
+        margin: 1rem 0;
+        td, th {
+            padding: 0.5rem 0.75rem;
+            border: 1px solid variables.$backstage-color-5;
+        }
+    }
+
+    pre {
+        padding: 1rem;
+        overflow-x: auto;
+        background: variables.$backstage-color-3;
+    }
+    
+    :not(pre) > code {
+        padding: 0.15rem 0.3rem;
+        background: variables.$backstage-color-3;
+    }
+
+    blockquote {
+        margin: 1rem 0;
+        padding: 0.5rem 0 0.1rem 1rem;
+        border-left: 4px solid variables.$backstage-color-5;
+        background: variables.$backstage-color-3;
+    }
+}
+
+

--- a/src/components/MarkdownCard.module.scss
+++ b/src/components/MarkdownCard.module.scss
@@ -5,9 +5,14 @@
     table {
         border-collapse: collapse;
         margin: 1rem 0;
-        td, th {
+        td {
             padding: 0.5rem 0.75rem;
             border: 1px solid variables.$backstage-color-5;
+        }
+        th {
+            padding: 0.5rem 0.75rem;
+            border: 1px solid variables.$backstage-color-5;
+            background: variables.$backstage-color-2;
         }
     }
 

--- a/src/components/MarkdownCard.tsx
+++ b/src/components/MarkdownCard.tsx
@@ -5,6 +5,7 @@ import { Button, Card } from 'react-bootstrap';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import EditTextModal from './utils/EditTextModal';
+import styles from './MarkdownCard.module.scss';
 
 type Props = {
     text: string;
@@ -37,7 +38,7 @@ const MarkdownCard: React.FC<Props> = ({ text, onSubmit, cardTitle, editModelTit
                     ) : null}
                 </Card.Header>
                 {showContent && text ? (
-                    <Card.Body>
+                    <Card.Body className={styles.markdownWrapper}>
                         <ReactMarkdown remarkPlugins={[remarkGfm]}>{text}</ReactMarkdown>
                     </Card.Body>
                 ) : null}


### PR DESCRIPTION
Add a few css rules to the markdown renderer to style tables, code, and blockquotes better. In particular, tables now have borders and padding.

<img width="410" height="362" alt="image" src="https://github.com/user-attachments/assets/436c13c0-2009-434b-ad2c-7becc872382d" />
